### PR TITLE
Add support to us2 region and add CustomCoraloigxArn and ByPassRegion variables[CDS-552]

### DIFF
--- a/coralogix-s3-archive/CHANGELOG.md
+++ b/coralogix-s3-archive/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## s3-archivea
+
+### 0.0.1 / 21.8.2023
+* [update] Add support to US2 and add an option to use CustomCoraloigxArn and ByPassRegion
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->

--- a/coralogix-s3-archive/README.md
+++ b/coralogix-s3-archive/README.md
@@ -2,7 +2,7 @@
 
 The module s3-archive will create s3 buckets to archive your coralogix logs, traces and metrics
 
-The module can run only on the following regions eu-west-1,eu-north-1,ap-southeast-1,ap-south-1,us-east-2.
+The module can run only on the following regions eu-west-1,eu-north-1,ap-southeast-1,ap-south-1,us-east-2,us-west-2.
 
 ## Fields
 

--- a/coralogix-s3-archive/README.md
+++ b/coralogix-s3-archive/README.md
@@ -8,6 +8,8 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 
 | Parameter | Description | Default Value | Required |
 |---|---|---|---|
+| CustomCoraloigxArn | In case that you ship logs from custom coralogix spesifie the aws id of this account. | n\a | |
+| ByPassRegion | Use only with approval from our CS team, use to bypass region restrictions | false | |
 | LogsBucketName | The name of the S3 bucket to create for the logs and traces archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | n\a | |
 | MetricsBucketName | The name of the S3 bucket to create for the metrics archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | n\a | |
 | MetricsKmsArn | The arn of your kms for the metrics bucket , Note: make sure that the kms is in the same region as your bucket | n\a | |

--- a/coralogix-s3-archive/README.md
+++ b/coralogix-s3-archive/README.md
@@ -8,7 +8,7 @@ The module can run only on the following regions eu-west-1,eu-north-1,ap-southea
 
 | Parameter | Description | Default Value | Required |
 |---|---|---|---|
-| CustomCoraloigxArn | In case that you ship logs from custom coralogix spesifie the aws id of this account. | n\a | |
+| CustomCoraloigxArn | In case you ship logs from custom coralogix account specify the aws id of this account. | n\a | |
 | ByPassRegion | Use only with approval from our CS team, use to bypass region restrictions | false | |
 | LogsBucketName | The name of the S3 bucket to create for the logs and traces archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | n\a | |
 | MetricsBucketName | The name of the S3 bucket to create for the metrics archive (Leave empty if not needed), Note: bucket name must follow [AWS naming rules](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html) | n\a | |

--- a/coralogix-s3-archive/template.yaml
+++ b/coralogix-s3-archive/template.yaml
@@ -26,7 +26,7 @@ Parameters:
     Description: 'Use only with approval from our CS team, use to bypass region restrictions'
     Default: "false"
 Conditions:
-  NewArnRegion: !Equals
+  IsRegionUs2: !Equals
         - !Ref 'AWS::Region'
         - us-west-2
   CustomArn: !Not
@@ -131,7 +131,7 @@ Resources:
                       - CustomArn
                       - !Ref CustomCoraloigxArn
                       - !If
-                        - NewArnRegion
+                        - IsRegionUs2
                         - "739076534691"
                         - "625240141681"
                       
@@ -184,7 +184,7 @@ Resources:
                       - CustomArn
                       - !Ref CustomCoraloigxArn
                       - !If
-                        - NewArnRegion
+                        - IsRegionUs2
                         - "739076534691"
                         - "625240141681"
             Resource:

--- a/coralogix-s3-archive/template.yaml
+++ b/coralogix-s3-archive/template.yaml
@@ -17,7 +17,25 @@ Parameters:
   LogsKmsArn:
     Type: String
     Description: 'The arn for the kms of the logs and traces bucket - leave empty if not needed'
+  CustomCoraloigxArn:
+    Type: String
+    Description: 'In case you want to use a custom coralogix arn enter the aws account id that you want to use'
+    Default: ""
+  ByPassRegion:
+    Type: String
+    Description: 'Use only with approval from our CS team, use to bypass region restrictions'
+    Default: "false"
 Conditions:
+  NewArnRegion: !Equals
+        - !Ref 'AWS::Region'
+        - us-west-2
+  CustomArn: !Not
+    - !Equals
+      - !Ref CustomCoraloigxArn
+      - ""
+  ByPassRegionTrue: !Equals
+      - !Ref ByPassRegion
+      - "True"
   IsLogsKmsNotEmpty: !Not
     - !Equals
       - !Ref LogsKmsArn
@@ -39,6 +57,9 @@ Conditions:
     - !Ref MetricsBucketName
   IsValidRegion: !Or
     - !Equals
+        - !Ref ByPassRegion
+        - "True"
+    - !Equals
         - !Ref 'AWS::Region'
         - eu-west-1
     - !Equals
@@ -53,6 +74,9 @@ Conditions:
     - !Equals
         - !Ref 'AWS::Region'
         - us-east-2
+    - !Equals
+        - !Ref 'AWS::Region'
+        - us-west-2
   LogsValidations: !And
     - !Not
       - !Condition IsSameBucketName
@@ -101,7 +125,16 @@ Resources:
               - 's3:GetObjectTagging'
             Effect: 'Allow'
             Principal: 
-              AWS: 'arn:aws:iam::625240141681:root'
+              AWS: !Sub 
+                  - 'arn:aws:iam::${aws_account_id}:root'
+                  - aws_account_id: !If
+                      - CustomArn
+                      - !Ref CustomCoraloigxArn
+                      - !If
+                        - NewArnRegion
+                        - "739076534691"
+                        - "625240141681"
+                      
             Resource:
               - !Sub 'arn:aws:s3:::${LogsBucketName}'
               - !Sub 'arn:aws:s3:::${LogsBucketName}/*'
@@ -145,7 +178,15 @@ Resources:
               - 's3:GetObjectTagging'
             Effect: 'Allow'
             Principal: 
-              AWS: 'arn:aws:iam::625240141681:root'
+              AWS: !Sub 
+                  - 'arn:aws:iam::${aws_account_id}:root'
+                  - aws_account_id: !If
+                      - CustomArn
+                      - !Ref CustomCoraloigxArn
+                      - !If
+                        - NewArnRegion
+                        - "739076534691"
+                        - "625240141681"
             Resource:
               - !Sub 'arn:aws:s3:::${MetricsS3Bucket}'
               - !Sub 'arn:aws:s3:::${MetricsS3Bucket}/*'


### PR DESCRIPTION
# Description
Add support to us2 region
Add variables:
* CustomCoraloigxArn - use to change the arn of the aws account id.
* ByPassRegion - use to bypass region restrictions.
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) -->

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)