### PR TITLE
Fix firehose integration alignment

### DIFF
--- a/aws-integrations/firehose/CHANGELOG.md
+++ b/aws-integrations/firehose/CHANGELOG.md
@@ -10,3 +10,6 @@
 
 ### 0.0.1 / 8 Sep 2023
 * [Update] Remove DynamicMetadata from metrics integration, changed name from DynamicMetadata to DynamicMetadataLogs
+
+### 0.0.1 / 30 Sep 2023
+* [Update] Made naming & update changes to align Firehose template with Integration team's firehose-metricss one.

--- a/aws-integrations/firehose/README.md
+++ b/aws-integrations/firehose/README.md
@@ -16,7 +16,7 @@ For a more detailed description of the settigns and architecture of this AWS Kin
 | ApiKey | Your Coralogix Private Key | |  :heavy_check_mark: |
 | ApplicationName | Your Coralogix Application name | | |
 | SubsystemName | Your Coralogix Subsystem name | | |
-| CustomUrl | The custom url domain. If set, will be the url used to send telemetry. | | |
+| CustomDomain | The custom url domain. If set, will be the url used to send telemetry. | | |
 
 ## Log Stream Parameters
 

--- a/aws-integrations/firehose/template.yaml
+++ b/aws-integrations/firehose/template.yaml
@@ -14,7 +14,7 @@ Parameters:
       - us
       - us2
     Default: ireland
-  CustomUrl:
+  CustomDomain:
     Type: String
     Description: The Custom url domain. If set, will be the url used to send telemetry.
     Default: ""
@@ -128,7 +128,7 @@ Metadata:
       - Label: 
           default: "Others"
         Parameters: 
-          - CustomUrl
+          - CustomDomain
           - CloudwatchRetentionDays
           - DynamicMetadataLogs
       - Label: 
@@ -168,7 +168,7 @@ Conditions:
   IsSubsystemName: !Not [!Equals [!Ref SubsystemName, ""]]
   IsIntegrationTypeLogs: !Not [!Equals [!Ref IntegrationTypeLogs, ""]]
   IsDynamicMetadataLogs: !Not [!Equals [ !Ref DynamicMetadataLogs, ""]]
-  IsCustomUrl: !Not [!Equals [ !Ref CustomUrl, ""]]
+  IsCustomDomain: !Not [!Equals [ !Ref CustomDomain, ""]]
   IsKinesisStreamAsSource: !Not [!Equals [ !Ref KinesisStreamAsSourceARN, "" ]]
   IsLogsEnabled: !Not [!Equals [ !Ref EnableLogsStream, "false" ]]
   IsMetricsEnabled: !Not [!Equals [ !Ref EnableMetricsStream, "false" ]]
@@ -178,7 +178,7 @@ Resources:
   BackupDataBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Sub '${AWS::StackName}-backup'
+      BucketName: !Sub '${AWS::StackId}-backup'
       AccessControl: Private
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
@@ -310,8 +310,8 @@ Resources:
         EndpointConfiguration:
           Url: 
             !If 
-              - IsCustomUrl
-              - !Ref CustomUrl
+              - IsCustomDomain
+              - !Ref CustomDomain
               - Fn::FindInMap: [ CoralogixRegionMap, !Ref CoralogixRegion, LogUrl ]
           AccessKey:
             Ref: ApiKey
@@ -322,12 +322,12 @@ Resources:
           CommonAttributes:
             - !If 
               - IsApplicationName
-              - AttributeName: 'applicationName'
+              - AttributeName: 'applicationNameDefault'
                 AttributeValue: !Ref ApplicationName
               - !Ref 'AWS::NoValue'
             - !If
               - IsSubsystemName
-              - AttributeName: 'subsystemName'
+              - AttributeName: 'subsystemNameDefault'
                 AttributeValue: !Ref SubsystemName
               - !Ref 'AWS::NoValue'
             - !If
@@ -512,8 +512,8 @@ Resources:
         EndpointConfiguration:
           Url: 
             !If 
-              - IsCustomUrl
-              - !Ref CustomUrl
+              - IsCustomDomain
+              - !Ref CustomDomain
               - Fn::FindInMap: [ CoralogixRegionMap, !Ref CoralogixRegion, LogUrl ]
           AccessKey:
             Ref: ApiKey
@@ -706,7 +706,7 @@ Resources:
 Outputs:
   BackupDataBucketName:
     Description: S3 Bucket where failed deliveries will be backed-up
-    Value: !Sub '${AWS::StackName}-backup'
+    Value: !Sub '${AWS::StackId}-backup'
   CoralogixDeliveryLogsStreamARN:
     Condition: IsLogsEnabled
     Description: The ARN for your Kinesis Firehose Delivery Stream, use this as the

--- a/aws-integrations/firehose/template.yaml
+++ b/aws-integrations/firehose/template.yaml
@@ -203,6 +203,7 @@ Resources:
     Condition: IsLogsEnabled
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Sub '${AWS::StackName}-cloudwatchlogs'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -570,7 +571,7 @@ Resources:
     Condition: IsMetricsEnabled
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub '${AWS::StackName}-cw'
+      RoleName: !Sub '${AWS::StackName}-cloudwatchmetrics'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -583,7 +584,7 @@ Resources:
     Condition: IsMetricsEnabled
     Type: AWS::IAM::Policy
     Properties:
-      PolicyName: !Sub '${AWS::StackName}-cw'
+      PolicyName: !Sub '${AWS::StackName}-cloudwatchmetrics'
       PolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
# Description

Changes requested by @anatsyg to get our CF template.yaml aligned with integration team's one
- Template parameters ApplicationName and SubsystemName should be used for applicationNameDefault and subsystemNameDefault parameters for CoralogixDeliveryLogsStream [Firehose endpoint doc](https://coralogix.com/docs/aws-firehose/)
- Make the CloudWatchLogsRole name follow the next pattern '${AWS::StackName}-cloudwatchlogs’ and other rolesname + policynames too
- StackId instead of StackName for S3 bucket as stacknames can repeat
- CustomUrl to CustomDomain

# How Has This Been Tested?

Tested Locally on AWS account
Name changes mainly, mostly non-functional

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)