### PR TITLE
Prometheus processor

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -6,7 +6,7 @@
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
 ### 0.0.5 / 2023-10-12
-* Added resourcedetection to metrics and traces of default configuration.
+* Added resourcedetection to metrics pipeline of default configuration.
 
 ### 0.0.4 / 2023-10-04
 * Removed ecsattributes filters from default configuration

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.5 / 2023-10-12
+* Added resourcedetection to metrics and traces of default configuration.
+
 ### 0.0.4 / 2023-10-04
 * Removed ecsattributes filters from default configuration
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -163,12 +163,16 @@ Mappings:
             traces:
               receivers:
                 - otlp
+              processors:
+                - resourcedetection
               exporters:
                 - coralogix
 
             metrics:
               receivers:
                 - prometheus
+              receivers:
+                - resourcedetection
               exporters:
                 - coralogix
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -163,8 +163,6 @@ Mappings:
             traces:
               receivers:
                 - otlp
-              processors:
-                - resourcedetection
               exporters:
                 - coralogix
 


### PR DESCRIPTION
BUG - Enable resourcedetection processor for
metric pipeline of 'Default' config

# Description

Added resourcedetection processor for the Metrics pipeline for the ''Default" OTEL configuration.

# How Has This Been Tested?

Deployed into ECS on EC2 hosts and observed resulting OTEL telemetry metrics having new attributes attached.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)