### PR TITLE
Add resource-metadata to sync github action

### DIFF
--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: upload files
     env:
-      integration_list: "s3,s3-sns,cloudtrail,cloudtrail-sns,cloudwatch-logs,vpc-flow-logs,firehose"
+      integration_list: "s3,s3-sns,cloudtrail,cloudtrail-sns,cloudwatch-logs,vpc-flow-logs,firehose,resource-metadata"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/aws-integrations/lambda-integrations/resource-metadata/CHANGELOG.md
+++ b/aws-integrations/lambda-integrations/resource-metadata/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## resource-metadata
 
+### 0.0.1 / 20.10.2023
+* [Update] Add changelog file and added resource-tags to github actions sync
+
 ### 0.0.1 / 15.8.2023
 * [update] Add an option to use an existing secret instead of creating a new one with SSM, and remove the SsmEnabled parameter.
 <!-- To add a new entry write: -->

--- a/aws-integrations/lambda-integrations/resource-metadata/template.yaml
+++ b/aws-integrations/lambda-integrations/resource-metadata/template.yaml
@@ -1,5 +1,6 @@
 #Created automatically from coralogix/coralogix-aws-serverless
 #Link to the repo: https://github.com/coralogix/coralogix-aws-serverless/tree/master/src/resource-metadata
+#
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
 Description: Send resource metadata  to  Coralogix.


### PR DESCRIPTION
# Description

Add resource-metadata to sync github action.

https://coralogix.atlassian.net/browse/VTX-3068

The idea is to recreate this PR with a more updated version: https://github.com/coralogix/integration-definitions/pull/51

Would this change be enough to do that?