### PR TITLE
Update default ECS-EC2 Otel Config

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,14 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.5 / 2023-10-23
+* Updated default ecs-ec2 default templates 
+    - removed  unnecessary OTEL_RESOURCE_ATTRIBUTES from default configuration  
+    - updated default `ecsattributes` config to include `docker.name`
+    - added resourcedetection for otel-collector metrics
+    - removed unnecssary differences between default and metric configurations
+
+
 ### 0.0.4 / 2023-10-04
 * Removed ecsattributes filters from default configuration
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -146,8 +146,12 @@ Mappings:
             application_name: "$APP_NAME"
             subsystem_name: "$SUB_SYS"
             application_name_attributes:
+            - "aws.ecs.cluster"
+            - "aws.ecs.cluster.name"
             - "aws.ecs.task.definition.family"
             subsystem_name_attributes:
+            - "aws.ecs.container.name"
+            - "aws.ecs.docker.name"
             - "docker.name"
             timeout: 30s
 
@@ -253,10 +257,13 @@ Mappings:
             application_name: "$APP_NAME"
             subsystem_name: "$SUB_SYS"
             application_name_attributes:
+            - "aws.ecs.cluster"
+            - "aws.ecs.cluster.name"
             - "aws.ecs.task.definition.family"
             subsystem_name_attributes:
-            - "docker.name"
+            - "aws.ecs.container.name"
             - "aws.ecs.docker.name"
+            - "docker.name"
             timeout: 30s
 
         service:

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -141,8 +141,8 @@ Mappings:
             subsystem_name: "$SUB_SYS"
             application_name_attributes:
             - "aws.ecs.task.definition.family"
-            # subsystem_name_attributes:
-            # - "docker.name"
+            subsystem_name_attributes:
+            - "docker.name"
             timeout: 30s
 
         service:
@@ -166,6 +166,8 @@ Mappings:
             metrics/otel-collector:
               receivers:
                 - prometheus
+              processors:
+                - resourcedetection/otel-collector
               exporters:
                 - coralogix
 
@@ -248,6 +250,7 @@ Mappings:
             - "aws.ecs.task.definition.family"
             subsystem_name_attributes:
             - "docker.name"
+            - "aws.ecs.docker.name"
             timeout: 30s
 
         service:

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -130,7 +130,13 @@ Mappings:
                   - set(attributes["aws_ecs_task_family"], attributes["aws.ecs.task.definition.family"])
                   - set(attributes["image_id"], attributes["image.id"])
                   - delete_key(attributes, "image.id")
-            
+
+          # otel-collector resource detection for collector
+          resourcedetection/otel-collector:
+            detectors: [ecs, ec2]
+            timeout: 2s
+            override: false
+
         exporters:
           logging:
             verbosity: detailed

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -34,13 +34,13 @@ Parameters:
         - US
         - US2
 
-  ApplicationName:
+  DefaultApplicationName:
     Type: String
     Description: The name of your application
     MinLength: 1
     MaxLength: 64
 
-  SubsystemName:
+  DefaultSubsystemName:
     Type: String
     Description: The subsystem name of your application
     MinLength: 1
@@ -68,7 +68,7 @@ Parameters:
     Default: "none"
 
 Conditions:
-  DefaultSubsystemName: !Equals [ !Ref SubsystemName, "default" ]
+  UseDefaultSubsystemName: !Equals [ !Ref DefaultSubsystemName, "default" ]
   Metrics: !Equals [ !Ref Metrics, "enable" ]
   UseCustomConfig: 
     Fn::Not: 
@@ -117,10 +117,6 @@ Mappings:
             override: false
 
           ecsattributes:
-            attributes:
-              - ^image$
-              - ^aws.*
-              - ^labels.*
             container_id:
               sources:
                 - "log.file.path"
@@ -132,6 +128,8 @@ Mappings:
                 statements:
                   - set(attributes["cx_container_id"], attributes["docker.id"])
                   - set(attributes["aws_ecs_task_family"], attributes["aws.ecs.task.definition.family"])
+                  - set(attributes["image_id"], attributes["image.id"])
+                  - delete_key(attributes, "image.id")
             
         exporters:
           logging:
@@ -143,8 +141,8 @@ Mappings:
             subsystem_name: "$SUB_SYS"
             application_name_attributes:
             - "aws.ecs.task.definition.family"
-            subsystem_name_attributes:
-            - "docker.name"
+            # subsystem_name_attributes:
+            # - "docker.name"
             timeout: 30s
 
         service:
@@ -165,7 +163,7 @@ Mappings:
               exporters:
                 - coralogix
 
-            metrics:
+            metrics/otel-collector:
               receivers:
                 - prometheus
               exporters:
@@ -232,7 +230,13 @@ Mappings:
                   - delete_key(attributes, "image.id")
 
           batch:
-                  
+
+          # otel-collector resource detection for collector
+          resourcedetection/otel-collector:
+            detectors: [ecs, ec2]
+            timeout: 2s
+            override: false
+
         exporters:
           logging:
           coralogix:
@@ -271,6 +275,14 @@ Mappings:
                 - otlp
               processors:
                 - batch
+              exporters:
+                - coralogix
+
+            metrics/otel-collector:
+              receivers:
+                - prometheus
+              processors:
+                - resourcedetection/otel-collector
               exporters:
                 - coralogix
 
@@ -353,28 +365,24 @@ Resources:
           Environment:
             - Name: CORALOGIX_DOMAIN
               Value: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Domain]
-
-            - Name: OTEL_RESOURCE_ATTRIBUTES
-              Value: !If
-                - DefaultSubsystemName
-                - !Sub "APP_NAME=${ApplicationName},SUB_SYS=${AWS::AccountId}"
-                - !Sub "APP_NAME=${ApplicationName},SUB_SYS=${SubsystemName}"
            
             - Name: PRIVATE_KEY
               Value: !Ref PrivateKey
 
             - Name: APP_NAME
-              Value: !Ref ApplicationName
+              Value: !Ref DefaultApplicationName
 
             - Name: SUB_SYS
-              Value: !Ref SubsystemName
+              Value: !If
+                - UseDefaultSubsystemName
+                - !Sub "${AWS::AccountId}"
+                - !Ref DefaultSubsystemName
 
             - Name: OTEL_CONFIG
               Value: !If
                 - Metrics
                 - !FindInMap [Otel, Config, Metrics]
                 - !FindInMap [Otel, Config, Default]
-
 
   OtelTaskDefinitionCustom: 
     Type: AWS::ECS::TaskDefinition
@@ -427,21 +435,18 @@ Resources:
           Environment:
             - Name: CORALOGIX_DOMAIN
               Value: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Domain]
-
-            - Name: OTEL_RESOURCE_ATTRIBUTES
-              Value: !If
-                - DefaultSubsystemName
-                - !Sub "APP_NAME=${ApplicationName},SUB_SYS=${AWS::AccountId}"
-                - !Sub "APP_NAME=${ApplicationName},SUB_SYS=${SubsystemName}"
            
             - Name: PRIVATE_KEY
               Value: !Ref PrivateKey
 
             - Name: APP_NAME
-              Value: !Ref ApplicationName
+              Value: !Ref DefaultApplicationName
 
             - Name: SUB_SYS
-              Value: !Ref SubsystemName
+              Value: !If
+                - UseDefaultSubsystemName
+                - !Sub "${AWS::AccountId}"
+                - !Ref DefaultSubsystemName
 
             - Name: OTEL_CONFIG
               Value: !Ref OtelConfig


### PR DESCRIPTION
* Updated default ecs-ec2 default templates 
    - removed  unnecessary OTEL_RESOURCE_ATTRIBUTES from default configuration  
    - updated default `ecsattributes` config to include `docker.name`
    - added resourcedetection for otel-collector metrics
    - removed unnecssary differences between default and metric configurations