### PR TITLE
Migrate transformation Lambda runtime

### DIFF
--- a/aws-integrations/firehose/CHANGELOG.md
+++ b/aws-integrations/firehose/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.1 / 25 Oct 2023
+* [Update] Migrate transformation Lambda runtime
+
 ### 0.0.1 / 28 Aug 2023
 * [Feature] Release of the Amazon Kinesis Data Firehose integration for logs and metrics
 

--- a/aws-integrations/firehose/template.yaml
+++ b/aws-integrations/firehose/template.yaml
@@ -418,10 +418,10 @@ Resources:
     Properties:
       Code:
         S3Bucket: !Sub 'cx-cw-metrics-tags-lambda-processor-${AWS::Region}'
-        S3Key: function.zip
+        S3Key: bootstrap.zip
       FunctionName: !Sub '${AWS::StackName}-metrics-transform'
-      Handler: function
-      Runtime: go1.x
+      Handler: bootstrap
+      Runtime: provided.al2
       Role: !GetAtt LambdaProcessorRole.Arn
       Timeout: 60
       MemorySize: 512

--- a/aws-integrations/firehose/template.yaml
+++ b/aws-integrations/firehose/template.yaml
@@ -422,6 +422,8 @@ Resources:
       FunctionName: !Sub '${AWS::StackName}-metrics-transform'
       Handler: bootstrap
       Runtime: provided.al2
+      Architectures: 
+      - arm64
       Role: !GetAtt LambdaProcessorRole.Arn
       Timeout: 60
       MemorySize: 512


### PR DESCRIPTION
# Description

Part of https://coralogix.atlassian.net/browse/ES-123.

Reflects the changes needed for migrating the runtime (for details see https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/).

This also has been reflected already in the transformation Lambda, see related change: https://github.com/coralogix/cloudwatch-metric-streams-lambda-transformation/pull/32

# How Has This Been Tested?

N/A

# Checklist:
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)