### PR TITLE
Add Healthcheck to ECS-EC2 default Otel config

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### 0.0.5 / 2023-10-25
 * Added Healthcheck to default ecs-ec2 configuration
+* Remove default image for otel ecs-ec2 template
 
 
 ### 0.0.5 / 2023-10-23

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.5 / 2023-10-25
+* Added Healthcheck to default ecs-ec2 configuration
+
+
 ### 0.0.5 / 2023-10-23
 * Updated default ecs-ec2 default templates 
     - removed  unnecessary OTEL_RESOURCE_ATTRIBUTES from default configuration  

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -21,17 +21,17 @@ This template can be used to deploy an ECS Service and Task Definition for runni
 
 ### Parameters:
 
-| Parameter       | Description                                                                                                                                                                                                                                                                                                                           | Default Value                                                                | Required           |
-|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
-| ClusterName     | The name of an **existing** ECS Cluster                                                                                                                                                                                                                                                                                               |                                                                              | :heavy_check_mark: |
-| Image           | The open telemtry collector container image.<br><br>By Default, this template uses the Coralogix Opentelemetry Collector Image, when using this image, you specify an image tag. The *:latest* tag is not updated. You can find a list of available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags) | coralogixrepo/otel-coralogix-ecs-ec2:*{version/tag}*                         |                    |
-| Memory          | The amount of memory to allocate to the Open Telemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster*                                                                                                  | 256                                                                          |                    |
-| CoralogixRegion | The region of your Coralogix Account                                                                                                                                                                                                                                                                                                  | *Allowed Values:*<br>- Europe<br>- Europe2<br>- India<br>- Singapore<br>- US | :heavy_check_mark: |
-| ApplicationName | You application name                                                                                                                                                                                                                                                                                                                  |                                                                              | :heavy_check_mark: |
-| SubsystemName   | You Subsystem name                                                                                                                                                                                                                                                                                                                    | AWS Account ID                                                               | :heavy_check_mark: |
-| PrivateKey      | Your Coralogix Private Key                                                                                                                                                                                                                                                                                                            |                                                                              | :heavy_check_mark: |
-| Metrics         | Enable/Disable Metrics                                                                                                                                                                                                                                                                                                                | disable                                                                      |                    |
-| OtelConfig      | The Base64 encoded Open Telemetry configuration yaml to use. This parameter allows you to pass your own Open Telemetry configuration. This will be used instead of the embedded configuration if specified.                                                                                                                           |                                                                              |                    |
+| Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                                | Required           |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
+| ClusterName      | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                              | :heavy_check_mark: |
+| CDOTImageVersion | The Coralogix Open Telemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                              |                    |
+| Memory           | The amount of memory to allocate to the Open Telemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                          |                    |
+| CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:*<br>- Europe<br>- Europe2<br>- India<br>- Singapore<br>- US | :heavy_check_mark: |
+| ApplicationName  | You application name                                                                                                                                                                                                                 |                                                                              | :heavy_check_mark: |
+| SubsystemName    | You Subsystem name                                                                                                                                                                                                                   | AWS Account ID                                                               | :heavy_check_mark: |
+| PrivateKey       | Your Coralogix Private Key                                                                                                                                                                                                           |                                                                              | :heavy_check_mark: |
+| Metrics          | Enable/Disable Metrics                                                                                                                                                                                                               | disable                                                                      |                    |
+| OtelConfig       | The Base64 encoded Open Telemetry configuration yaml to use. This parameter allows you to pass your own Open Telemetry configuration. This will be used instead of the embedded configuration if specified.                          |                                                                              |                    |
 
 ### Deploy the Cloudformation template:
 
@@ -53,6 +53,7 @@ aws cloudformation deploy --template-file cfn_template.yaml --stack-name <stack_
     --parameter-overrides \
         ApplicationName=<application name> \
         ClusterName=<ecs cluster name> \
+        CDOTImageVersion=<image tag> \
         PrivateKey=<your-private-key> \
         OTELConfig=$(cat path/to/otelconfig.yaml | base64) \
         CoralogixRegion=<coralogix-region>
@@ -67,7 +68,6 @@ The Open Telemetry configuration is embedded in this cloudformation template by 
 The default configuration will monitor container logs and listen for traces on port `4317/4318`. To enable metrics, set the `Metrics` parameter to `enabled`. This will add the `awsecscontainermetricsd` receiver which is based on the [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) receiver, however, instead of monitoring a single task, metrics will be collected from all containers.
 
 The default Open Telemetry configuration can be view [here](./template.yaml#L75-L161) and the metrics [here](./template.yaml#L164-L262).
-
 
 ### Health Check
 
@@ -86,7 +86,6 @@ The healthy response should look like this:
 ### Image
 
 This example uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
-
 
 ### Open Telemetry Collector Metrics
 

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -1,4 +1,4 @@
-cu### ECS Service and Task Definition
+### ECS Service and Task Definition
 
 This template can be used to deploy an ECS Service and Task Definition for running the Open Telemetry agent on an ECS Cluster. This deployment is able to collect Logs, Metrics and Traces. The template will deploy a daemonset which runs an instance open telemetry on each node in a cluster.
 
@@ -67,6 +67,21 @@ The Open Telemetry configuration is embedded in this cloudformation template by 
 The default configuration will monitor container logs and listen for traces on port `4317/4318`. To enable metrics, set the `Metrics` parameter to `enabled`. This will add the `awsecscontainermetricsd` receiver which is based on the [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) receiver, however, instead of monitoring a single task, metrics will be collected from all containers.
 
 The default Open Telemetry configuration can be view [here](./template.yaml#L75-L161) and the metrics [here](./template.yaml#L164-L262).
+
+
+### Health Check
+
+The default config will expose a health check on port `13133` of the localhost via the path `/`. The health check is exposed using the [health_check](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/extension/healthcheckextension) extension.
+
+The healthy response should look like this:
+
+```json
+{
+  "status": "Server available",
+  "upSince": "2023-10-25T15:37:32.003837622Z",
+  "uptime": "2m5.2610063s"
+}
+```
 
 ### Image
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -8,13 +8,20 @@ Parameters:
   ClusterName:
     Type: String
 
+  CDOTImageVersion:
+    Description: |
+      The Coralogix Open Telemetry Distribution Image
+      Version/Tag.
+      View available tags here: https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags
+    Type: String
+  
   Image:
     Description: |
-      The opentelemetry image used to start the container.
-      This defaults to the coralogixrepo/coralogix-otel-collector image.
-      https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags
+      The OpenTelemetry Collector Image to use.
+      If specified, this value will override the CDOTImageVersion parameter and
+      the coralogix otel collector image.
+    Default: none
     Type: String
-    Default: coralogixrepo/coralogix-otel-collector:v0.1.2
 
   Memory:
     Description: |
@@ -70,6 +77,7 @@ Parameters:
 Conditions:
   UseDefaultSubsystemName: !Equals [ !Ref DefaultSubsystemName, "default" ]
   Metrics: !Equals [ !Ref Metrics, "enable" ]
+  UseImage: !Not [!Equals [ !Ref Image, "none" ]]
   UseCustomConfig: 
     Fn::Not: 
     - !Equals [ !Ref OtelConfig, "none" ]
@@ -362,7 +370,11 @@ Resources:
         - Name: coralogix-otel-agent
           Cpu: 0
           Memory: !Ref Memory
-          Image: !Ref Image
+          Image: !If
+            - UseImage
+            - !Ref Image
+            - !Sub "coralogixrepo/coralogix-otel-collector:${CDOTImageVersion}"
+
           Essential: true
 
           PortMappings:
@@ -432,9 +444,12 @@ Resources:
         - Name: coralogix-otel-agent
           Cpu: 0
           Memory: !Ref Memory
-          Image: !Ref Image
+          Image: !If
+            - UseImage
+            - !Ref Image
+            - !Sub "coralogixrepo/coralogix-otel-collector:${CDOTImageVersion}"
+            
           Essential: true
-
           PortMappings:
             - HostPort: 4317
               Protocol: tcp

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -155,7 +155,13 @@ Mappings:
             - "docker.name"
             timeout: 30s
 
+        extensions:
+          health_check:
+
         service:
+          extensions:
+            - health_check
+
           pipelines:
             logs:
               receivers: 
@@ -265,8 +271,13 @@ Mappings:
             - "aws.ecs.docker.name"
             - "docker.name"
             timeout: 30s
+          
+        extensions:
+          health_check:
 
         service:
+          extensions:
+            - health_check
           pipelines:
             logs:
               receivers: 


### PR DESCRIPTION
Addes health_check extension to default otel ecs-ec2 configuration template.
Removed Default image from ecs-ec2 otel cfn template.
