### PR TITLE
Gh Actions: fix for inability to do branch and checkout together

### DIFF
--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -104,8 +104,11 @@ jobs:
           echo "branch_name: ${branch_name}"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git remote update
+          git fetch
           git pull origin master
-          git checkout -b ${branch_name}
+          git branch ${branch_name}
+          git checkout ${branch_name}
           sync_branch_exists=$(git ls-remote --heads origin "${branch_name}" | wc -l)
           if [[ $sync_branch_exists -ne 0 ]]; then
             git pull origin ${branch_name} --rebase


### PR DESCRIPTION
# Description

Split the `git checkout -b $branch_name` to branch and checkout separately.
also added `git fetch` lines.

# How Has This Been Tested?

Separate PR on separate branches, with the Gh Actions.

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)