### PR TITLE
deprecation fix for annotation warning

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -23,7 +23,7 @@ jobs:
     needs: get-label
     name: Check changelog update
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Get changed files

--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -45,19 +45,19 @@ jobs:
           fi
 
       - name: Upload template-directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: template-directory
           path: ./template-directory/
 
       - name: Upload changed-integration
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: changed-integration
           path: ./changed-integration.txt
   
       - name: Upload replace_template script
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: replace_template
           path: scripts/replace_template.sh
@@ -68,7 +68,7 @@ jobs:
     steps:
 
       - name: Checkout destination repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: coralogix/integration-definitions
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Description
actions/upload-artifact@v2 -> actions/upload-artifact@v3
actions/checkout@v2 -> actions/checkout@v3

# How Has This Been Tested?

gh-actions on separate branches

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)