### PR TITLE
Fix ECS Fargate CloudFormation template ssm name, use nginx demo

### DIFF
--- a/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
+++ b/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
@@ -12,7 +12,7 @@ Parameters:
       - US2
   PrivateKey:
     Type: String
-    Description: The Coralogix private key which is used to validate your authenticity
+    Description: The Coralogix Send-Your-Data API Key which is used to validate your authenticity
     NoEcho: true
   S3ConfigARN:
     Type: String
@@ -112,12 +112,12 @@ Resources:
       ExecutionRoleArn: !GetAtt ECSExecutionRole.Arn
       NetworkMode: awsvpc
       ContainerDefinitions:
-        - Name: node-app
-          Image: mikebriggs2k/nodeapp:0.0.6
+        - Name: demo
+          Image: nginx
           Cpu: 0
           PortMappings:
-            - ContainerPort: 8080
-              HostPort: 8080
+            - ContainerPort: 80
+              HostPort: 80
               Protocol: tcp
           Essential: true
           Environment: []
@@ -155,7 +155,7 @@ Resources:
           VolumesFrom: []
           Secrets:
             - Name: AOT_CONFIG_CONTENT
-              ValueFrom: config.yaml
+              ValueFrom: /OTEL/config.yaml
           LogConfiguration:
             LogDriver: awsfirelens
             Options:


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Minor fix for otel-collector container SSM parameter name.
Change demo app to use open nginx container.

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Follow instructions at https://coralogix.com/docs/aws-ecs-fargate/ 
Fixes error encountered when deploying the Task Definition:
```ResourceInitializationError: unable to pull secrets or registry auth: execution resource retrieval failed: unable to retrieve secrets from ssm: service call has been retried 1 time(s): invalid ssm parameters: config.yaml``` 

Error caused by incorrect SSM parameter path

Also uses nginx as demo container, serves port 80 without errors.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)