### PR TITLE
Update sync action to skip create_pr job instead of failing

### DIFF
--- a/.github/workflows/Changelog.yaml
+++ b/.github/workflows/Changelog.yaml
@@ -1,7 +1,7 @@
 name: Changelog
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled, unlabeled]
     branches: [master]
     paths:
       - "**/template.*"

--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   upload_files:
     runs-on: ubuntu-latest
+    outputs:
+      has_file_from_the_list_changed: ${{ env.has_template_from_the_list_changed }}
     name: upload files
     env:
       integration_list: "s3,s3-sns,cloudtrail,cloudtrail-sns,cloudwatch-logs,vpc-flow-logs,firehose-logs,firehose-metrics,resource-metadata,aws-shipper-lambda"
@@ -40,7 +42,9 @@ jobs:
           done
           if [ -z "$(ls -A "./template-directory")" ]; then
             echo "[INFO] No file in the integrations list where changed."
-            exit 1
+            echo "has_template_from_the_list_changed=false" >> $GITHUB_ENV
+          else
+            echo "has_template_from_the_list_changed=true" >> $GITHUB_ENV
           fi
 
       - name: Upload template-directory
@@ -63,6 +67,7 @@ jobs:
 
   create_pr:
     runs-on: ubuntu-latest
+    if: "${{ needs.upload_files.outputs.has_file_from_the_list_changed != 'false' }}"
     needs: upload_files
     steps:
 


### PR DESCRIPTION
# Description
Sync action will now skip the create_pr job in case that a template that is not on the list has been changed
also update the changelog action to get trigger when there is a new label for the pr 
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)