### PR TITLE
Update Image Parameter for Prometheus Auto Discovery template

### DIFF
--- a/prometheus/ecs-ec2/autodiscovery/CHANGELOG.md
+++ b/prometheus/ecs-ec2/autodiscovery/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## prometheus ecs-ec2 autodiscovery
+
+- Removed default image parameter from autodiscovery workflow template
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->

--- a/prometheus/ecs-ec2/autodiscovery/README.md
+++ b/prometheus/ecs-ec2/autodiscovery/README.md
@@ -24,7 +24,7 @@ In order for a Prometheus target container to be detected by the Cloudwatch Agen
 | ExecutionRoleName   | Enter the CloudWatch Agent ECS execution role name                                                                | String | `ECSDiscoveryCWAgentExecutionRoleName` |          |
 | CoralogixRegion     | The Coralogix location region                                                                                     | String | `Europe`                               | ✔️        |
 | CoralogixPrivateKey | The Coralogix Private Key                                                                                         | String | `NoEcho: true`                         | ✔️        |
-| ImageTag            | The Coralogix Otel Collector image tag.<br>see [here](coralogixrepo/coralogix-otel-collector) for available tags: | String |                                        |          |
+| ImageTag            | The Coralogix Otel Collector image tag.<br>see [here](coralogixrepo/coralogix-otel-collector) for available tags: | String |                                        | ✔️        |
 
 ##### Open Telemetry Collector Configuration
 

--- a/prometheus/ecs-ec2/autodiscovery/README.md
+++ b/prometheus/ecs-ec2/autodiscovery/README.md
@@ -15,17 +15,16 @@ In order for a Prometheus target container to be detected by the Cloudwatch Agen
 
 ##### Parameters:
 
-| Parameter                   | Description                                                                          | Type   | Default                                                                                                      | Required |
-|-----------------------------|--------------------------------------------------------------------------------------|--------|--------------------------------------------------------------------------------------------------------------|----------|
-| ECSClusterName              | Enter the name of your ECS cluster from which you want to collect Prometheus metrics | String |                                                                                                              | ✔️        |
-| CreateIAMRoles              | Whether to create new IAM roles or use an existing IAM roles for the ECS tasks       | String | `True`                                                                                                       |          |
-| ECSNetworkMode              | ECS Network Mode for the Task                                                        | String | `bridge`                                                                                                     |          |
-| TaskRoleName                | Enter the CloudWatch Agent ECS task role name                                        | String | `ECSDiscoveryCWAgentTaskRoleName`                                                                            |          |
-| ExecutionRoleName           | Enter the CloudWatch Agent ECS execution role name                                   | String | `ECSDiscoveryCWAgentExecutionRoleName`                                                                       |          |
-| CoralogixRegion             | The Coralogix location region                                                        | String | `Europe`                                                                                                     | ✔️        |
-| CoralogixPrivateKey         | The Coralogix Private Key                                                            | String | `NoEcho: true`                                                                                               | ✔️        |
-| Image                       | The Open Telemetry container image                                                   | String | [coralogixrepo/otel-coralogix-ecs-ec2](https://hub.docker.com/r/coralogixrepo/otel-coralogix-ecs-ec2:latest) |          |
-
+| Parameter           | Description                                                                                                       | Type   | Default                                | Required |
+|---------------------|-------------------------------------------------------------------------------------------------------------------|--------|----------------------------------------|----------|
+| ECSClusterName      | Enter the name of your ECS cluster from which you want to collect Prometheus metrics                              | String |                                        | ✔️        |
+| CreateIAMRoles      | Whether to create new IAM roles or use an existing IAM roles for the ECS tasks                                    | String | `True`                                 |          |
+| ECSNetworkMode      | ECS Network Mode for the Task                                                                                     | String | `bridge`                               |          |
+| TaskRoleName        | Enter the CloudWatch Agent ECS task role name                                                                     | String | `ECSDiscoveryCWAgentTaskRoleName`      |          |
+| ExecutionRoleName   | Enter the CloudWatch Agent ECS execution role name                                                                | String | `ECSDiscoveryCWAgentExecutionRoleName` |          |
+| CoralogixRegion     | The Coralogix location region                                                                                     | String | `Europe`                               | ✔️        |
+| CoralogixPrivateKey | The Coralogix Private Key                                                                                         | String | `NoEcho: true`                         | ✔️        |
+| ImageTag            | The Coralogix Otel Collector image tag.<br>see [here](coralogixrepo/coralogix-otel-collector) for available tags: | String |                                        |          |
 
 ##### Open Telemetry Collector Configuration
 
@@ -85,7 +84,6 @@ The Open Telemetry configuration used for this template is [embedded in the temp
           extensions:
             - ecs_observer
 ```
-
 
 ##### Deploy
 
@@ -163,15 +161,13 @@ The contents should look similar to the following:
     __metrics_path__: /metrics
 ```
 
-- By default the Open Telemetry collector is configured to send to Coralogix. You can also verify that the Prometheus scrape endpoints are being scraped by checking the Coralogix console. 
-<br>
-- If data is not being received, check to make sure that there is network connectivity between the Scraper and all the targets. In order for targets to be scraped from within the ECS Cluster, the relevant security groups need to allow sufficient inbound/outbound access to the Open Telemetry collector and the Prometheus targets.
-<br>
+- By default the Open Telemetry collector is configured to send to Coralogix. You can also verify that the Prometheus scrape endpoints are being scraped by checking the Coralogix console. <br>
+- If data is not being received, check to make sure that there is network connectivity between the Scraper and all the targets. In order for targets to be scraped from within the ECS Cluster, the relevant security groups need to allow sufficient inbound/outbound access to the Open Telemetry collector and the Prometheus targets. <br>
 - If targets are not being detected, check to make sure that labels are defined correctly. Also note that if the port or path specific are invalid or do not represent a prometheus compatible endpoint, the target will not be detected. For eg. If we set the `ECS_PROMETHEUS_EXPORTER_PORT` to `8080` and the `ECS_PROMETHEUS_METRICS_PATH` to `/metrics`, the target will not be detected if the Prometheus endpoint does not expose metrics on port `8080` with the path `/metrics` path.
 
 ---
 
-This template is meant to be a starting point for leveraging Open Telemetry for Prometheus Auto Discovery in ECS-EC2 using Docker Labels, it is also possible to detect prometheus endpoints using other patterns, such as Service Name. 
+This template is meant to be a starting point for leveraging Open Telemetry for Prometheus Auto Discovery in ECS-EC2 using Docker Labels, it is also possible to detect prometheus endpoints using other patterns, such as Service Name.
 
 The detection mechanism can also detect any prometheus compatible endpoint, not just the Prometheus Node Exporters. For eg. Cadvisor, Prometheus Push Gateway, etc.
 

--- a/prometheus/ecs-ec2/autodiscovery/template.yaml
+++ b/prometheus/ecs-ec2/autodiscovery/template.yaml
@@ -45,10 +45,11 @@ Parameters:
     Description: The Coralogix Private Key
     NoEcho: true
   
-  Image:
+  ImageTag:
     Type: String
-    Description: Open Telemetry Collector Image
-    Default: coralogixrepo/otel-coralogix-ecs-ec2:latest
+    Description: |
+      The coralogix-otel-collector image tag.
+      see https://hub.docker.com/r/otel/opentelemetry-collector-contrib/tags for available tags
 
 Conditions:
   CreateRoles:
@@ -231,7 +232,7 @@ Resources:
 
       ContainerDefinitions:
         - Name: opentelemetry-agent-prometheus
-          Image: !Ref Image
+          Image: !Sub 'coralogixrepo/coralogix-otel-collector:${ImageTag}'
           Essential: true
 
           MountPoints:


### PR DESCRIPTION
This Pr removes the default image from the Promtheus Autodiscovery template.
Users must specify the image tag explicitly
