### PR TITLE
Manual trigger bug fix for action publish and sync

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       refToBuild:
-        description: 'Branch, tag or commit SHA1 to build'
+        description: 'Branch, tag or commit SHA1'
         required: true
         type: string
   push:
@@ -17,9 +17,18 @@ jobs:
     name: publish
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout when triggered by commit
+        uses: actions/checkout@v4
+        if: "${{ inputs.refToBuild == null }}"
         with:
+          persist-credentials: false
+          fetch-depth: 0
+          
+      - name: checkout when trigger manually
+        uses: actions/checkout@v4
+        if: "${{ inputs.refToBuild != null }}"
+        with:
+          ref: ${{ inputs.refToBuild }}
           persist-credentials: false
           fetch-depth: 0
 

--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -20,9 +20,16 @@ jobs:
     env:
       integration_list: "s3,s3-sns,cloudtrail,cloudtrail-sns,cloudwatch-logs,vpc-flow-logs,firehose-logs,firehose-metrics,resource-metadata,aws-shipper-lambda"
     steps:
-      - uses: actions/checkout@v3
+      - name: checkout when trigger is from push
+        uses: actions/checkout@v4
+        if: "${{ inputs.refToBuild == null }}"
         with:
           fetch-depth: 0 
+      - name: checkout when trigger manually
+        uses: actions/checkout@v4
+        if: "${{ inputs.refToBuild != null }}"
+        with:
+          ref: ${{ inputs.refToBuild }}
 
       - name: Create template-directory and changed-integration-file
         run: |


### PR DESCRIPTION
# Description
The checkout action should get the files from the commit that is passing in case that you trigger manually, in other cases it will get the current files
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)