### PR TITLE
S3 archive update role for metrics bucket [CDS-982]

### DIFF
--- a/coralogix-s3-archive/CHANGELOG.md
+++ b/coralogix-s3-archive/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## s3-archivea
+## s3-archive
 
 ### 0.0.3 / 17.1.2024
 * [Bug Fix] Changed the role for metrics bucket

--- a/coralogix-s3-archive/CHANGELOG.md
+++ b/coralogix-s3-archive/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## s3-archivea
 
+### 0.0.3 / 17.1.2024
+* [Bug Fix] Changed the role for metrics bucket
+
 ### 0.0.2 / 7.1.2024
 * [update] Update the lambda role premission
 

--- a/coralogix-s3-archive/template.yaml
+++ b/coralogix-s3-archive/template.yaml
@@ -194,15 +194,14 @@ Resources:
             Effect: 'Allow'
             Principal: 
               AWS: !Sub 
-                - 'arn:aws:iam::${aws_account_id}:role/coralogix-archive-${aws_role_region}'
-                - aws_role_region: !FindInMap [CoralogixRegionMap, !Ref 'AWS::Region', RoleRegion]
-                  aws_account_id: !If
-                    - CustomArn
-                    - !Ref CustomCoraloigxArn
-                    - !If
-                      - IsRegionUs2
-                      - "739076534691"
-                      - "625240141681"
+                  - 'arn:aws:iam::${aws_account_id}:root'
+                  - aws_account_id: !If
+                      - CustomArn
+                      - !Ref CustomCoraloigxArn
+                      - !If
+                        - IsRegionUs2
+                        - "739076534691"
+                        - "625240141681"
             Resource:
               - !Sub 'arn:aws:s3:::${MetricsS3Bucket}'
               - !Sub 'arn:aws:s3:::${MetricsS3Bucket}/*'


### PR DESCRIPTION
# Description
Update the role for the metrics bucket, the new role `arn:aws:iam::${aws_account_id}:role/coralogix-archive-${aws_role_region}` is working right now only for logs and not metrics
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) -->

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)