### PR TITLE
move the aws-shipper lambda in the sync to shared folder

### DIFF
--- a/.github/workflows/synchronizing.yaml
+++ b/.github/workflows/synchronizing.yaml
@@ -132,8 +132,13 @@ jobs:
           while read line; do  
             ./replace_template.sh template-directory/${line}-template.yaml
             template_version=$(cat template-directory/${line}-template.yaml | grep "SemanticVersion" | grep -oE '[^ ]+$')
-            mkdir -p integrations/${line}/v${template_version}
-            mv template-directory/${line}-template.yaml integrations/${line}/v${template_version}/template.yaml
+            if [ "$line" == "aws-shipper-lambda" ];then
+              mkdir -p integrations/shared/aws-shipper/v${template_version}
+              mv template-directory/${line}-template.yaml integrations/shared/aws-shipper/v${template_version}/template.yaml
+            else
+              mkdir -p integrations/${line}/v${template_version}
+              mv template-directory/${line}-template.yaml integrations/${line}/v${template_version}/template.yaml
+            fi
             
             if [ -f integrations/${line}/manifest.yaml ]; then
               echo "  - revision: ${template_version}


### PR DESCRIPTION
# Description
In integration-definition the aws-shipper-lambda is now under the shared folder so i have update the sync to create the new template under the shared folder
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)