### PR TITLE
Coralogix OpenTelemetry Agent for ECS-EC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cloudformation Corlaogix AWS
+# Cloudformation Coralogix AWS
 
 This repo contains AWS Cloudformation templates utilised for Coralogix Integrations. Templates can be copied and executed directly via the AWS Console or using AWS CLI or other Cloudformation management utilities.
 

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.6 / 2024-02-13
+- [update],[otel]: Restrict mount vol scope; enable metrics otlp; enable batch with defaults. Soft-deprecate previous cx region codes for replacements; Hard-deprecate param name `PrivateKey` for `CoralogixApiKey`; Readme content sync with terraform version, formatting.
+
 ### 0.0.5 / 2024-01-15
 - Added pprof extension to default ecs-ec2 otel configuration
 

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -1,13 +1,15 @@
 # Coralogix OpenTelemetry Agent for ECS-EC2. Cloudformation template.
 
-This template can be used to deploy an ECS Service and Task Definition for running the Open Telemetry agent on an ECS Cluster. This deployment is able to collect Logs, Metrics and Traces. The template will deploy a daemonset which runs an instance open telemetry on each node in a cluster.
+This CloudFormation template deploys an ECS Service and Task Definition for running the Open Telemetry agent on an ECS Cluster. This deployment is able to collect Logs, Metrics and Traces. The template will deploy a daemonset which runs an instance open telemetry on each node in a cluster.
 
-### Image
+CloudFormation template to launch the Coralogix Distribution for Open Telemetry ("CDOT") into an existing ECS Cluster. This CDOT deployment is able to collect Logs, Metrics and Traces. CDOT is deployed in the OTEL [Agent deployment](https://opentelemetry.io/docs/collector/deployment/agent/) pattern, as an ECS Daemon Service type, which runs an instance of the Open Telemetry collector agent on each node in a cluster.
 
-This example
-[comment]: <> (Clarification: should the repo be positioned as prod supported code? 'This solution' vs 'This example'? Are we not as a team already supporting this package anyway? What is our actual support posture?)
-[comment]: <> (This is a markdown comment, it should not be rendered)
-uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
+## Image
+
+<!--
+'solution' vs 'example'. We are as a team already supporting this repo. What should be our actual support posture? If this repo is positioned as "supported" by CX? Then:'This solution', is more accurate than:'This example'.
+-->
+This example uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
 
 The OTEL collector/agent/daemon image used is the [Coralogix Distribution for Open Telemetry](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector) Docker Hub image. It is deployed as a [_Daemon_](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon) ECS Task, i.e. one OTEL collector agent container on each EC2 instance (i.e. ECS container instance) across the cluster.
 
@@ -17,27 +19,27 @@ The OTEL agent is deployed as a Daemon ECS Task and connected using [```host``` 
 
 The CDOT OTEL agent also features enhancements specific to ECS integration. These improvements are proprietary to the Coralogix Distribution for Open Telemetry.
 
-**Logs**
+### Logs
 
 The OTEL agent uses a [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filereceiver) to read the docker logs of all containers on the EC2 host. OTLP is also accepted. Coralogix provides the ```awsecscontainermetricsd``` receiver which enables metrics collection of all tasks on the same host. The [coralogix exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter) forwards telemetry to your configured Coralogix endpoint.
 
-> Logs are collected from all containers that log to `/var/lib/docker/containers/*/*.log`
-> The container requires privileges to mount the host read-only file path `/var/lib/docker/`.
+Logs are collected from all containers that log to `/var/lib/docker/containers/*/*.log`.
+The container requires privileges to mount the host read-only file path `/var/lib/docker/`.
 
-**Metrics**
+### Metrics
 
-> Metrics are collected from all containers running on the ECS Cluster. The metrics are collected using the [awsecscontainermetricsd](./components.md#awsecscontainermetricsd) receiver.
+Metrics are collected from all containers running on the ECS Cluster. The metrics are collected using the [awsecscontainermetricsd](./components.md#awsecscontainermetricsd) receiver.
 
-**Traces**
+### Traces
 
-> A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the local OTLP endpoint.
+A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the local OTLP endpoint.
 
-**Requires:**
+### Requires:
 
 - An existing ECS Cluster
 - [aws-cli]() (*if deploying via CLI*)
 
-### Parameters:
+## Parameters:
 
 | Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                                | Required           |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
@@ -52,7 +54,7 @@ The OTEL agent uses a [filelog receiver](https://github.com/open-telemetry/opent
 | Metrics          | Enable/Disable Metrics                                                                                                                                                                                                               | disable                                                                      |                    |
 | OtelConfig       | The Base64 encoded Open Telemetry configuration yaml to use. This parameter allows you to pass your own Open Telemetry configuration. This will be used instead of the embedded configuration if specified.                          |                                                                              |                    |
 
-### Deploy the Cloudformation template:
+## Deploy the Cloudformation template:
 
 ```sh
 aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -69,8 +69,9 @@ Parameters:
 
   PrivateKey:
     Type: String
-    Description: "Deprecated. Hard-replaced by \"CoralogixApiKey\". Must be null. Formerly: The Coralogix private key which is used to validate your authenticity."
-    AllowedPattern: "^$" # hard-deprecate.
+    Description: "Deprecated. Do not use. Hard-replaced by \"CoralogixApiKey\". Formerly: The Coralogix private key which is used to validate your authenticity."
+    Default: "DO-NOT-USE"
+    AllowedPattern: "^DO-NOT-USE$" # hard-deprecate.
     NoEcho: true
 
   Metrics:

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -449,7 +449,7 @@ Resources:
 
           MountPoints:
             - SourceVolume: hostfs
-              ContainerPath: "/hostfs"
+              ContainerPath: "/hostfs/var/lib/docker"
               ReadOnly: True
 
             - SourceVolume: docker-socket

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -28,12 +28,18 @@ Parameters:
       The amount of memory (in MiB) used by the task.
       Note that you cluster must have sufficient memory available to support the given value.
     Type: Number
-    Default: 256
+    Default: "256"
 
   CoralogixRegion:
       Type: String
-      Description: The Coralogix location region [Europe, Europe2, India, Singapore, US, US2]
+      Description: "The Coralogix location region [EU1|EU2|AP1|AP2|US1|US2]. Deprecated: [Europe, Europe2, India, Singapore, US, US2]"
       AllowedValues:
+        - EU1
+        - EU2
+        - AP1
+        - AP2
+        - US1
+        - US2
         - Europe
         - Europe2
         - India
@@ -44,19 +50,27 @@ Parameters:
   DefaultApplicationName:
     Type: String
     Description: The name of your application
-    MinLength: 1
-    MaxLength: 64
+    MinLength: "1"
+    MaxLength: "64"
 
   DefaultSubsystemName:
     Type: String
     Description: The subsystem name of your application
-    MinLength: 1
-    MaxLength: 64
+    MinLength: "1"
+    MaxLength: "64"
     Default: "default"
+
+  CoralogixApiKey:
+    Type: String
+    Description: "The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/"
+    NoEcho: true
+    AllowedPattern: ".+"
+    ConstraintDescription: "API Key required."
 
   PrivateKey:
     Type: String
-    Description: The Coralogix private key which is used to validate your authenticity
+    Description: "Deprecated. Hard-replaced by \"CoralogixApiKey\". Must be null. Formerly: The Coralogix private key which is used to validate your authenticity."
+    AllowedPattern: "^$" # hard-deprecate.
     NoEcho: true
 
   Metrics:
@@ -102,15 +116,13 @@ Mappings:
               - job_name: otel-collector-metrics
                 scrape_interval: 60s
                 static_configs:
-                - targets: ['localhost:8888']
+                - targets: ["localhost:8888"]
 
           filelog:
             start_at: end
             include:
               - /hostfs/var/lib/docker/containers/*/*.log
-
             include_file_path: true
-
             # add log.file.path to resource attributes
             operators:
               - type: move
@@ -138,6 +150,11 @@ Mappings:
                   - set(attributes["aws_ecs_task_family"], attributes["aws.ecs.task.definition.family"])
                   - set(attributes["image_id"], attributes["image.id"])
                   - delete_key(attributes, "image.id")
+
+          batch:
+            send_batch_size: 1024
+            send_batch_max_size: 2048
+            timeout: "1s"
 
           # otel-collector resource detection for collector
           resourcedetection/otel-collector:
@@ -186,6 +203,8 @@ Mappings:
             traces:
               receivers:
                 - otlp
+              processors:
+                - batch
               exporters:
                 - coralogix
 
@@ -194,6 +213,7 @@ Mappings:
                 - prometheus
               processors:
                 - resourcedetection/otel-collector
+                - batch
               exporters:
                 - coralogix
 
@@ -223,9 +243,7 @@ Mappings:
             start_at: end
             include:
               - /hostfs/var/lib/docker/containers/*/*.log
-              
             include_file_path: true
-
             # add log.file.path to resource attributes
             operators:
               - type: move
@@ -258,6 +276,9 @@ Mappings:
                   - delete_key(attributes, "image.id")
 
           batch:
+            send_batch_size: 1024
+            send_batch_max_size: 2048
+            timeout: "1s"
 
           # otel-collector resource detection for collector
           resourcedetection/otel-collector:
@@ -290,6 +311,7 @@ Mappings:
           extensions:
             - health_check
             - pprof
+
           pipelines:
             logs:
               receivers: 
@@ -303,6 +325,7 @@ Mappings:
 
             metrics:
               receivers:
+                - otlp
                 - awsecscontainermetricsd
               processors:
                 - batch
@@ -322,6 +345,7 @@ Mappings:
                 - prometheus
               processors:
                 - resourcedetection/otel-collector
+                - batch
               exporters:
                 - coralogix
 
@@ -332,6 +356,24 @@ Mappings:
 
 
   CoralogixRegionMap:
+    EU1:
+      Endpoint: ingress.coralogix.com:443
+      Domain: coralogix.com
+    EU2:
+      Endpoint: ingress.eu2.coralogix.com:443
+      Domain: eu2.coralogix.com
+    AP1:
+      Endpoint: ingress.coralogix.in:443
+      Domain: coralogix.in
+    AP2:
+      Endpoint: ingress.coralogixsg.com:443
+      Domain: coralogixsg.com
+    US1:
+      Endpoint: ingress.coralogix.us:443
+      Domain: coralogix.us
+    US2:
+      Endpoint: ingress.cx498-aws-us-west-2.coralogix.com:443
+      Domain: cx498.coralogix.com
     Europe:
       Endpoint: ingress.coralogix.com:443
       Domain: coralogix.com
@@ -364,7 +406,7 @@ Resources:
       Volumes:
         - Name: hostfs
           Host:
-            SourcePath: "/"
+            SourcePath: "/var/lib/docker/"
   
         - Name: docker-socket
           Host:
@@ -418,7 +460,7 @@ Resources:
               Value: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Domain]
            
             - Name: PRIVATE_KEY
-              Value: !Ref PrivateKey
+              Value: !Ref CoralogixApiKey
 
             - Name: APP_NAME
               Value: !Ref DefaultApplicationName
@@ -446,7 +488,7 @@ Resources:
       Volumes:
         - Name: hostfs
           Host:
-            SourcePath: "/"
+            SourcePath: "/var/lib/docker/"
   
         - Name: docker-socket
           Host:
@@ -491,7 +533,7 @@ Resources:
               Value: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Domain]
            
             - Name: PRIVATE_KEY
-              Value: !Ref PrivateKey
+              Value: !Ref CoralogixApiKey
 
             - Name: APP_NAME
               Value: !Ref DefaultApplicationName


### PR DESCRIPTION
#  Description

<!-- Please describe the changes you made in a few words or sentences. -->

OTEL Agent ECS-EC2:

- Restrict mount vol scope; 
- Enable metrics otlp; 
- Enable batch with defaults. 
- Soft-deprecate previous cx region codes for replacements; 
- Hard-deprecate param name `PrivateKey` for `CoralogixApiKey`. 
- Readme content sync with terraform version and general improvement.

<!-- (provide issue number, if applicable; otherwise remove) -->

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

1. Deployment to ECS Fargate cluster via AWS CLI.
    * https://frank.app.coralogix.us/#/query-new/logs?id=4m3Pg0OkEIy&page=0
    * https://ap-northeast-1.console.aws.amazon.com/ecs/v2/clusters/test-lab-cluster/services?region=ap-northeast-1
    * https://ap-northeast-1.console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/stackinfo?filteringText=&filteringStatus=active&viewNested=true&stackId=arn%3Aaws%3Acloudformation%3Aap-northeast-1%3A035955823196%3Astack%2Ftest-lab-cluster%2Fa2c2c200-c9aa-11ee-be73-06e133fe224b
2. Prevent use of `PrivateKey` param.
    * CLI: 
    ```
    aws cloudformation deploy --template-file template.yaml --stack-name test-lab-cluster \
    --parameter-overrides \
        DefaultApplicationName=default_app_name_should_not_see \
        CDOTImageVersion=latest \
        ClusterName=test-lab-cluster \
        PrivateKey=${SEND_API_KEY_PROD} \
        CoralogixRegion=US1
    ```
    * response:
    ```
     An error occurred (ValidationError) when calling the CreateChangeSet operation: Parameter 'PrivateKey' must match pattern ^DO-NOT-USE$
    ```

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)