### PR TITLE
fix ecs ec2 default config

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 0.0.8 / 2024-03-13
+- Fixed ECS EC2 default Otel configuration filelog receiver include statement to match the new mount scope
+
 ### 0.0.7 / 2024-02-23
 - Updated ECS EC2 default Otel configuration to log level warn.
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -122,7 +122,7 @@ Mappings:
           filelog:
             start_at: end
             include:
-              - /hostfs/var/lib/docker/containers/*/*.log
+              - /hostfs/containers/*/*.log
             include_file_path: true
             # add log.file.path to resource attributes
             operators:
@@ -245,7 +245,7 @@ Mappings:
           filelog:
             start_at: end
             include:
-              - /hostfs/var/lib/docker/containers/*/*.log
+              - /hostfs/containers/*/*.log
             include_file_path: true
             # add log.file.path to resource attributes
             operators:


### PR DESCRIPTION
This PR updates the default filelog receiver in the ecs ec2 otel config to match the new mount path following the changes made here: https://github.com/coralogix/cloudformation-coralogix-aws/pull/117 
