### PR TITLE
new module that will create role that will be used my metrics integration [CDS-1155]

### DIFF
--- a/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## AwsMetrics
+
+### 11.4.2024
+### 🚀 New components 🚀
+- Create metrics integration module
+

--- a/coralogix-metrics-integration-policy/README.md
+++ b/coralogix-metrics-integration-policy/README.md
@@ -1,0 +1,11 @@
+# Aws Metrics integration Role
+
+The module will create a role to be used with AwsMetrics integration
+
+## Fields
+
+| Parameter | Description | Default Value | Required |
+|-----------|-------------|---------------|----------|
+| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, dev, staging, custom] | EU1 | :heavy_check_mark: |
+| RoleName | The name of the rule that template will create in your AWS account | n\a | :heavy_check_mark: |
+| CustomeAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |

--- a/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-metrics-integration-policy/template.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: The module will create a role with an inline policy to allow Coralogix to send events to an EventBridge event bus.
+Parameters:
+  AWSAccount:
+    Type: String
+    Default: EU1
+    Description: The AWS account that you want to deploy the integration in.
+    AllowedValues:
+      - dev
+      - staging
+      - EU1
+      - EU2
+      - AP1
+      - Ap2
+      - US1
+      - US2
+      - CustomEndpoint
+  RoleName:
+    Type: String
+    Description: The name of the role that will be created.
+  CustomeAccountId:
+    Type: String
+    Description: Custom AWS account ID that you want to deploy the integration in.
+    Default: ''
+
+Mappings:
+  AWSAccountId:
+    dev: 
+      ID: 233273809180
+    staging: 
+      ID: 233221153619
+    EU1: 
+      ID: 625240141681
+    EU2: 
+      ID: 625240141681
+    AP1: 
+      ID: 625240141681
+    Ap2: 
+      ID: 625240141681
+    US1: 
+      ID: 625240141681
+    US2: 
+      ID: 739076534691
+    CustomEndpoint:
+      ID: 000000000000
+
+Conditions:
+  IsCustomAccountId: !Not [!Equals [!Ref CustomeAccountId, '']]
+Resources:
+  CoralogixAwsMetricsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Description: description
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub
+                - 'arn:aws:iam::${aws_account_id}:root'
+                - aws_account_id: !If
+                  - IsCustomAccountId
+                  - !Ref CustomeAccountId
+                  - !FindInMap [AWSAccountId, !Ref AWSAccount, 'ID']
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CoralogixMetricsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - tag:GetResources
+                  - cloudwatch:GetMetricStatistics
+                  - cloudwatch:ListMetrics
+                Resource: "*"


### PR DESCRIPTION
# Description
Created a new module that will create a role, the role will allow: tag:GetResources, cloudwatch:GetMetricStatistics, cloudwatch:ListMetrics to all resource.
The role will have trusting relationship with the AWS account that the user will choose using the `AWSAccount` or `CustomeAccountId`
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)