### PR TITLE
Update cloudwatch metric integrations rights

### DIFF
--- a/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## AwsMetrics
 
+### 23.4.2024
+### New permission needed
+- Add permission `cloudwatch:GetMetricData` to the policy
+
 ### 11.4.2024
 ### 🚀 New components 🚀
 - Create metrics integration module

--- a/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-metrics-integration-policy/template.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+  AWSTemplateFormatVersion: 2010-09-09
 Description: The module will create a role with an inline policy to allow Coralogix to send events to an EventBridge event bus.
 Parameters:
   AWSAccount:
@@ -73,6 +73,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - tag:GetResources
+                  - cloudwatch:GetMetricData
                   - cloudwatch:GetMetricStatistics
                   - cloudwatch:ListMetrics
                 Resource: "*"

--- a/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-metrics-integration-policy/template.yaml
@@ -1,4 +1,4 @@
-  AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: 2010-09-09
 Description: The module will create a role with an inline policy to allow Coralogix to send events to an EventBridge event bus.
 Parameters:
   AWSAccount:


### PR DESCRIPTION
We are using new API to fetch metrics.

# Description

We need one more permission, because we use one more API for getting metrics.

# How Has This Been Tested?

I have added better logging and it now fails on missing access in the integration.
