### PR TITLE
set metrics type aggregations as default

### DIFF
--- a/aws-integrations/firehose-metrics/CHANGELOG.md
+++ b/aws-integrations/firehose-metrics/CHANGELOG.md
@@ -34,3 +34,6 @@
 
 ### 0.0.4 / 7 Dec 2023
 * [Update] Remove CloudWatch_Metrics_JSON metrics integrationType option
+
+### 0.0.5 / 7 May 2024
+* [Update] default CloudWatch_Metrics_OpenTelemetry070_WithAggregations metrics integrationType option

--- a/aws-integrations/firehose-metrics/README.md
+++ b/aws-integrations/firehose-metrics/README.md
@@ -23,7 +23,7 @@ For a more detailed description of the settigns and architecture of this AWS Kin
 
 | Parameter | Description | Default Value | Required |
 |---|---|---|---|
-| IntegrationTypeMetrics | The data structure of the Firehose delivery stream for metrics | _Allowed Values:_<br>- CloudWatch_Metrics_OpenTelemetry070<br>- CloudWatch_Metrics_OpenTelemetry070_WithAggregations<br> _Default_: CloudWatch_Metrics_OpenTelemetry070 | |
+| IntegrationTypeMetrics | The data structure of the Firehose delivery stream for metrics. For `CloudWatch_Metrics_OpenTelemetry070_WithAggregations`, additional aggregations here are `_min`, `_max`, `_avg` recorded as gauges. See https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-opentelemetry-translation.html | _Allowed Values:_<br>- CloudWatch_Metrics_OpenTelemetry070<br>- CloudWatch_Metrics_OpenTelemetry070_WithAggregations<br> _Default_: CloudWatch_Metrics_OpenTelemetry070_WithAggregations | |
 | OutputFormat | The output format of the cloudwatch metric stream | _Allowed Values:_<br>- opentelemetry0.7<br>- json<br> _Default_: opentelemetry0.7 | |
 | IncludeNamespaces | A string comma-delimited list of namespaces to include to the metric stream <br>e.g. `AWS/EC2,AWS/EKS,AWS/ELB,AWS/Logs,AWS/S3` | | |
 | IncludeNamespacesMetricNames | A string json list of namespaces and metric_names to include to the metric stream. JSON stringify the input to avoid format errors. <br>e.g. {"AWS/EC2":["CPUUtilization","NetworkOut"],"AWS/S3":["BucketSizeBytes"]} | | |

--- a/aws-integrations/firehose-metrics/template.yaml
+++ b/aws-integrations/firehose-metrics/template.yaml
@@ -37,11 +37,11 @@ Parameters:
     Default: 1
   IntegrationTypeMetrics:
     Type: String
-    Description: "The integration type of the firehose delivery stream [CloudWatch_Metrics_OpenTelemetry070, CloudWatch_Metrics_OpenTelemetry070_WithAggregations] - default: CloudWatch_Metrics_OpenTelemetry070"
+    Description: "The integration type of the firehose delivery stream [CloudWatch_Metrics_OpenTelemetry070, CloudWatch_Metrics_OpenTelemetry070_WithAggregations] - default: CloudWatch_Metrics_OpenTelemetry070_WithAggregations"
     AllowedValues:
       - CloudWatch_Metrics_OpenTelemetry070
       - CloudWatch_Metrics_OpenTelemetry070_WithAggregations
-    Default: CloudWatch_Metrics_OpenTelemetry070
+    Default: CloudWatch_Metrics_OpenTelemetry070_WithAggregations
   OutputFormat:
     Type: String
     Description: "The output format of the cloudwatch metric stream [opentelemetry0.7, json] - default: opentelemetry0.7."
@@ -86,7 +86,7 @@ Parameters:
     Default: 'true'
 
 Metadata:
-  SemanticVersion: 0.0.4
+  SemanticVersion: 0.0.5
   AWS::CloudFormation::Interface: 
     ParameterGroups: 
       - Label: 


### PR DESCRIPTION
# Description

default metrics type set as CloudWatch_Metrics_OpenTelemetry070_WithAggregations

# How Has This Been Tested?

Locally

# Checklist:
- [X] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)