### PR TITLE
Add more permissions to archive for delete, and interchanged ap1 and ap2 regions [FASTV2-1262]

### DIFF
--- a/coralogix-s3-archive/CHANGELOG.md
+++ b/coralogix-s3-archive/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## s3-archive
 
+### 0.0.4 / 19.5.2024
+* [update] 
+ - Add delete permissions to the buckets rule
+ - replaced ap1 with ap2 in the mapping
+
 ### 0.0.3 / 17.1.2024
 * [Bug Fix] Changed the role for metrics bucket
 

--- a/coralogix-s3-archive/template.yaml
+++ b/coralogix-s3-archive/template.yaml
@@ -192,7 +192,6 @@ Resources:
               - 's3:GetObject'
               - 's3:ListBucket'
               - 's3:PutObject'
-              - 's3:DeleteObject'
               - 's3:PutObjectTagging'
               - 's3:GetObjectTagging'
               - 's3:DeleteObject'

--- a/coralogix-s3-archive/template.yaml
+++ b/coralogix-s3-archive/template.yaml
@@ -67,10 +67,10 @@ Conditions:
         - eu-north-1
     - !Equals
         - !Ref 'AWS::Region'
-        - ap-southeast-1
+        - ap-south-1
     - !Equals
         - !Ref 'AWS::Region'
-        - ap-south-1
+        - ap-southeast-1
     - !Equals
         - !Ref 'AWS::Region'
         - us-east-2
@@ -94,9 +94,9 @@ Mappings:
     eu-north-1:
       RoleRegion: eu2
     ap-southeast-1:
-      RoleRegion: ap1
-    ap-south-1:
       RoleRegion: ap2
+    ap-south-1:
+      RoleRegion: ap1
     us-east-2:
       RoleRegion: us1
     us-west-2:
@@ -137,6 +137,10 @@ Resources:
               - 's3:PutObject'
               - 's3:PutObjectTagging'
               - 's3:GetObjectTagging'
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectVersion'
+              - 's3:DeleteObjectTagging'
+              - 's3:DeleteObjectVersionTagging'
             Effect: 'Allow'
             Principal: 
               AWS: !Sub 
@@ -191,6 +195,10 @@ Resources:
               - 's3:DeleteObject'
               - 's3:PutObjectTagging'
               - 's3:GetObjectTagging'
+              - 's3:DeleteObject'
+              - 's3:DeleteObjectVersion'
+              - 's3:DeleteObjectTagging'
+              - 's3:DeleteObjectVersionTagging'
             Effect: 'Allow'
             Principal: 
               AWS: !Sub 


### PR DESCRIPTION
# Description
Add delete permissions to the bucket rule, and update ap1 and ap2 regions in the mapping:
ap1: ap-south-1
ap2: ap-southeast-1

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)