### PR TITLE
Minor Updates to ECS-EC2 windows Doc and Template

### DIFF
--- a/opentelemetry/ecs-ec2-windows/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2-windows/CHANGELOG.md
@@ -5,5 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+
+### 0.0.1 / 2024-05-22
+* Minor documentation updates
+* Updated hardcoded template value for the otel image used in the OtelConfig parameter
+
 ### 0.0.1 / 2023-09-11
 * Added EC2 ECS Windows Example for metrics collection

--- a/opentelemetry/ecs-ec2-windows/README.md
+++ b/opentelemetry/ecs-ec2-windows/README.md
@@ -15,7 +15,7 @@ This template section provides an example template for deployin the Open Telemet
 | Parameter       | Description                                                                                                                                                                                                                          | Default Value                                                                | Required           |
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
 | ClusterName     | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                              | :heavy_check_mark: |
-| OTelImage           | The open telemtry collector container image.<br><br>ECR Images must be prefixed with the ECR image URI. For eg. `<AccountID>.dkr.ecr.<REGION>.amazonaws.com/image:tag`                                                               | coralogixrepo/otel-coralogix-ecs-ec2                                         |                    |
+| OTelImage           | The open telemtry collector container image.<br><br>ECR Images must be prefixfd with the ECR image URI. For eg. `<AccountID>.dkr.ecr.<REGION>.amazonaws.com/image:tag`                                                               | coralogixrepo/otel-coralogix-ecs-ec2                                         |                    |
 | AppImage          | Your windows application container image |                                                                          |                    |
 | CoralogixRegion | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:*<br>- Europe<br>- Europe2<br>- India<br>- Singapore<br>- US | :heavy_check_mark: |
 | ApplicationName | You application name                                                                                                                                                                                                                 |                                                                              | :heavy_check_mark: |
@@ -26,7 +26,7 @@ This template section provides an example template for deployin the Open Telemet
 
 ### How it works
 
-This deployment uses the the [awsecscontainermetricsd](../ecs-ec2/components.md#aws-ecs-container-metrics-daemonset-receiver) receiver by Coralogix, to collect metrics from Windows application. For windows deployments the receiver must be deployed in Sidecar mode.
+This deployment uses the [awsecscontainermetricsd](../ecs-ec2/components.md#aws-ecs-container-metrics-daemonset-receiver) receiver by Coralogix, to collect metrics from Windows applications. For windows deployments the receiver must be deployed in Sidecar mode.
 
 ```yaml
 receivers:
@@ -40,8 +40,9 @@ For Windows, this receiver does not support being run as a daemonset, as such, e
 
 ### Open Telemetry Configuration
 
-The Open Telemetry configuration is embedded in this cloudformation template by default, however, you do have the option of specifying your own configuration my modifying the template. The  The Coralogix Open Telemetry distribution supports reading configration from S3 as well as an Envrionmentat Variable. Note that Environment variables can be raw strings or Base64 encoded. Configuration from S3 must be passed to the collector using the S3 URL of the object, for example `cdot --config s3://{your-bucket}.s3.{region}.amazonaws.com/{your-object-key}`, when using this feature in ECS, the host or task must have sufficient permissions to read S3 Objects.
+The Open Telemetry configuration is embedded in this CloudFormation template by default. However, you have the option of specifying your own configuration by modifying the template. The Coralogix Open Telemetry distribution supports reading configuration from S3 as well as from an Environment Variable. Note that environment variables can be raw strings or Base64 encoded. Configuration from S3 must be passed to the collector using the S3 URL of the object. For example: cdot --config `s3://{your-bucket}.s3.{region}.amazonaws.com/{your-object-key}`. When using this feature in ECS, the host or task must have sufficient permissions to read S3 objects.
 
 ### Image
 
-This example uses the [coralogixrepo/coralogix-otel-collector:0.1.0-windowsserver-1809](https://hub.docker.com/layers/coralogixrepo/coralogix-otel-collector/0.1.0-windowsserver-1809/images/sha256-c436b2b29501592449e2b72a2393f4825e7216bdd62d90cb5e14463a46fafd95?context=explore) image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](../ecs-ec2/components.md)
+This example uses the _windows-server-1809_ tagged version of the [coralogixrepo/coralogix-otel-collector](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags) image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](../ecs-ec2/components.md)
+

--- a/opentelemetry/ecs-ec2-windows/template.yaml
+++ b/opentelemetry/ecs-ec2-windows/template.yaml
@@ -8,7 +8,7 @@ Parameters:
 
   OtelImage:
     Type: String
-    Default: coralogixrepo/coralogix-otel-collector:0.1.0-windowsserver-1809
+    Default: coralogixrepo/coralogix-otel-collector:0.2.10-windowsserver-1809
 
   PrivateKey:
     Type: String


### PR DESCRIPTION
- [cds-724] re-add sync workflow (#10)  * initial commit  * Example of receiving the S3 payload  * newline_pattern  * sending to coralogix  * sending as batch  * Put records in ExportLogsServiceRequest  * sent to coralogix working  * added gzip at source  * Limit batch size to 500 logs  * Adding integration_type  * Implement splitting with fancy regexes  * WIP Blocking Pattern  * Blocking Working  * wip sampling blocking_pattern  * WIP DynamicAppName  * WIP dyn app  * Dynamic application/subsystem name  * added cloudtrail support WIP  * Cloudwatch working  * WIP Severity  * Severity fix  * Severity Matcher  * Resource per app/subsystem  * git ignored cargo.lock  * cloudtrail working  * initial sns  * sns working  * Working SNS  * Split initial  * Split initial  * vpcflow working  * Cloudwatch work in progress  * Cloudwatch work in progress  * Refactor/split code  * initial template  * added sam makefile  * added workfllows  * updated triggers  * adjust workflow  * added requirements txt  * add ssh agent  * add proto  * add sudo  * change lambda name  * change name  * add license  * updated Author  * added version change check  * fix exit  * added job depenedencies  * adjust push  * [skip-version-check]  CoralogixRegionMap the log URL should actually be the domain and than we need to build CORALOGIX_URL from it with prefix/sufix the reason for it are 2 like in here we wanted just one place to change if the URL changes (the domain is not) the support of CustomDomain that i see currently missing from the setting the URL should be https://ingress.coralogix.com:443 so currently  prefix is https://ingress domain is coralogix.com sufix :443` (not sure if sufix is needed or can stay empty for now CoralogixRegion  should custom option and this should be the default setting unless someone select otherwise something similar to what we did for firehose PrivateKey should be changed to ApiKey not sure that we have MaxLength for application or subsystem names (i know we have it now but not sure we have limit on our backend) we need to add ParameterGroups in the template (like we discuss so the template will be more readable) we also have it in some of the current templates not sure about the labels list (i think we should remove athena,query,results) Description i think should be Send logs to Coralogix from AWS since we will have also cloudwatch not sure that we need BufferSize i dont think we have any what about FunctionArchitecture we should give option to run on x86_64 or arm64 (default should be arm64) the lambda description should be generic not like now CustomResourceLambdaTriggerFunction should be only in case it is S3, we need to add some condition so when we will have cloudwatch this will not be trigger so need to think how to create it and also support the cloudwatch parmas i think it is only CloudWatchLogGroupName for S3KeyPrefix/S3KeySuffix how do we set them per the use case? i.e in cloudtrail they should be set by default missing SNSTopicArn param so if customer want to use his topic he should add the ARN and we need to register to this topic missing SamplingRate missing BlockingPattern missing NewlinePattern which is different syntax than what we currently have like juan explained why the python runtime for the CustomResourceLambdaTriggerFunction is 3.9 and not latest 3.11 we need probably a new param IntegrationType so they can set S3/Cloudtarail/Cloudwatch/VPC-Flow/etc...  * [skip-version-check] fix variable declaration  * [skip-version-check] removed AWS::LanguageExtension transform  * [skip-version-check] fix dependson  * [skip-version-check] fix code uri  * template updated  * adjust template  * Cloudwatch working  * thread_id WIP  * [skip-version-check] fixed UseSNSTopicARM condition and updated function variables  * gitignore  * Add thread_id to log_record  * [skip-version-check] Added metadata for grouping parameters. Set the Newline Param to empty by default. Set the S3KeyPrefix var to empty by default.  * [skip-version-check] update lambdafunction key name in store workflow  * update sync workflow  * change workflow name  * add -f flag  * add signing -S  * [skip-version-check] updated suffix  * updated s3 suffix  * [skip-version-check] updated  * Send batches in parallel  * [skip-version-check] added rule assertion for parameter validation, updated metadata label grouping  * LogMode::Vanilla  * [skip-version-check]  * merge fix  * [skip-version-check] update descriptions  * [skip-version-check] update retention description  * WOIP  * Cloudwatch fix  * CW Fix  * fix errors in main  * fix  * Fix Cargo.lock  * dependency update  * add get_api_key_from_secrets_manager  * adjust main function to support fetching secret  * [skip-version-check] added SecretStore variable and fixed Assertion  * added planetscale workflow  * updated  * adjust repo  * added content write  * add sync call  * updated repo name  * dependencies  * fix api key  * [skip-version-check]  Fixed cloudwatchgroupname parameter Fixed cloudwatch custom resource function parameters Removed S3 trigger for SNS topic deployment Added Stackid to Secret creation name  * addded custom sync  * remove separate sync workflow  * fix merge conflicts  * re-add sync workflow  * remove sync step  ---------  Co-authored-by: juan-coralogix <juan@coralogix.com> Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com> Co-authored-by: juan-coralogix <89215136+juan-coralogix@users.noreply.github.com>
- Update endpoints (#91)
- Change the sync action[CDS-865] (#17)  * add custom to the region mapping and change the sync action to replace the codeuri  Signed-off-by: guyrenny <guy.renny@coralogix.com>  * update the tempalte.yaml to incloud custom in region mapping  Signed-off-by: guyrenny <guy.renny@coralogix.com>  ---------  Signed-off-by: guyrenny <guy.renny@coralogix.com>
- [CDS-799] Feature/s3_csv (#18)  * S3_CSV Feature added
- [skip-version-check] CDS-799 Fix Max Memory in template (#19)
- update sync action to work with rust lambda (#92)
- Update template.yaml (#21)
- Vpc support [skip-version-check] (#23)  * FEAT - Support for deploying into VPC  * FIX - Remove second LogsPerBatch  * FIX - Restore Lambda MaxValue to 10240  * [skip-version-check] CDS-799 SNS Text function (#22)  * [skip-version-check] CDS-799 SNS Text function  * Update src/main.rs  unwrap remove  Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com>  * Update src/process.rs  Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com>  * Fix clone issue  ---------  Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com>  * add variable max_elapesed_time (#25)  * FEAT - Add PrivateLink conditionals and validation  * CHORE - Update CHANGELOG.md  ---------  Co-authored-by: juan-coralogix <89215136+juan-coralogix@users.noreply.github.com> Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com> Co-authored-by: juan-coralogix <juan@coralogix.com>
- Updated readme file with all params (#27)
- [skip-version-check] Update README.md (#28)  * [skip-version-check] Update README.md  * Update README.md  * Update README.md
- Update synchronizing.yaml (#94)
- Sync tets[CDS-870] (#31)  * Update template.yaml  * Update template.yaml
- [skip-version-check] CDS-719 add csvdelimiter variable (#35)  * [skip-version-check] add csvdelimiter variable
- [cds-724] Update cloudformation template (#34)  * [skip-version-check]  - s3 bucket name should not be mandatory need to update the regex probebly to validate it is minimum 3 latters - Add note for prefix/sufix that it is not working with sns and add condition to validate it is empty when sns is used so it will not confuse customers - change serverless function name to coralogix-aws-shipper - S3KeySuffix for VPC flowlog default suffix set to  .json.gz and default Prefix set to AWSLogs - removed LogsPerBatch param - added note to description saying this a beta release  * [skip-version-check] added badge for publish workflow  * [skip-version-check] adjust branch location  * [skip-version-check] updated s3 param  * [skip-version-check] adjust discription for s3bucket  * [skip-version-check] fix license badge  * [skip-version-check]removed default prefix for s3 integration  * [skip-version-check] adjust cargo version to match template  * [skip-version-check] add badged  * [skip-version-check] updated cloudwatch filter name  * [skip-version-check] re-add event on failure to cloudwatch lambda  * [skip-version-check] change badge name
- adjust badges (#38)
- Readme add
- [cds-724] Update template syntax (#43)  * [cds-724] Update cloudformation template  * Update template syntax  * [cds-724] Update template syntax
- [cds-724] Update readme (#44)
- fix bug in replace_template.sh (#95)
- [skip-version-check] Add data source and user agent headers (#45)  * Add data source and user agent headers  * Adjust readme and CF/SAM template  * Fixed version validation
- [skip-version-check] CDS-719 - Blocking Fn for all S3 (#48)  Blocking Fn for all S3
- remove CloudWatch_Metrics_JSON (#96)
- [skip-version-check] CDS-719 Update Changelog.yaml (#54)  * Update Changelog.yaml
- [cds-724] Final checks (#56)
- [cds-724] Update with small changed (#61)  * Update README.md  * Update template.yaml  * Update CHANGELOG.md  * Update README.md  * Update config.rs  Added Sns support
- Filter the list of lambda functions which should be the subject of metadata collection#feature/NGSTN-464-metadata-lambda-filtering
- Feature/ngstn 464 fix readme table#feature/NGSTN-464-fix-readme-table
- [skip-version-check]change the prefix and suffix to the vpcflow[CDS-719] (#64)  * change the prefix and suffix to the vpcflow  * skip cahngelog
- [skip-version-check] CDS-719 Fix/lastone (#66)  * changed newline example  * added csv empty line fix
- [cds-719][skip-version-check] Readme update (#69)  * Readme update
- [skip-version-check][cds-719] Hide newline and blocking pattern values if not set (#70)  * [skip-version-check] added default empty string for NEWLINE_PATTERN and BLOCKING_PATTERN  * [skip-version-check] NEWLINE and BLOCKING pattern env vars made to not show if not set  * Update template.yaml  * Update CHANGELOG.md  ---------  Co-authored-by: royfur <121816837+royfur@users.noreply.github.com>
- update version badege
- readme
- [cds-719] Version Update (#1)  * updated version  * removed test file  * align cargo.toml version with template version  * changelog  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Small fixes in Readme (#2)
- CDS-897 Elasticsearch to Opensearch Reports#CDS-897-es-opensearch-reports
- Deprecate resource tags#deprecate-resource-tags
- [ecs-fargate] fix CloudFormation template ssm name, use nginx demo (#93)
- Stop resource-metadata from failing on issue with single lambda function#feature/NGSTN-477-improve-resource-metadata-error-handling
- V0.0.2 (#3)  * fix zero file error  * add key on gz error  * changelog  * Update CHANGELOG.md  * variable set  * changlog update  * changed default logging level  * Added Rust Report Card  * Update version to 0.0.2  * Fix default LogLevel  * added file size in s3 logging  * align cargo.toml version with template version  ---------  Co-authored-by: royfur <121816837+royfur@users.noreply.github.com> Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- [skip-version-check] Fix LogLevel Typo (#4)  * fix typo in template  * changelog
- Fix issue with coralogixApiKey (#97)
- [skip-version-check] fixed readme version link (#5)
- Update README.md (#98)
- Correct conversion of tags to attributes#feature/NGSTN-480-fix-tag-to-attribute-conversion
- [cds-902] Integration Testing (#6)  * updated dependencies  * moved internal logic to lib.rs  * initial commit for integration tests  * removed unused imports  * added comments to test macro  * udpate s3 event  * changelog  * changelog  * add bad code  * bad code  * updated dependencies  * refactored integration tests  * Added mock s3 client and removed the need to call aws apis. Add local test files, refactored tests  * added formatting  * dependencies  * moved s3 key decoding into s3 handler function directly  * moved s3 key decoding  * added test_s3_event_handler  * move test_handle_s3_event to unit test  * add tests workflow  * add tag step
- Publish v0.0.3 (#11)  * release v0.0.3  * align cargo.toml version with template version  * align changelog with version  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Add CF template for assigning EventBridge policy (#100)
- Remove platform from code owners (#101)
- Update sync action to skip create_pr job instead of failing (#102)
- Update Image Parameter for Prometheus Auto Discovery template (#104)
- Bump tj-actions/changed-files from 37 to 41 in /.github/workflows (#105)
- Update aws eventbridge template to use role (#106)
- v0.0.5 (#20)  * v0.0.5  * align cargo.toml version with template version  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Fix eventbridge description (#107)
- Update parameters to track in replace_template.sh script (#103)
- Add sqs to allowed values in integrationType (#21)  * add sqs to allowed values in integrationType  * align cargo.toml version with template version  * Update CHANGELOG.md  * Update Cargo.toml version  * align cargo.toml version with template version  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Update the bucket role permissions [PLTD-478] (#108)
- Release v0.0.7 (#24)  * Release v0.0.7  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Add role name eventbridge (#109)
- Add option to run the action manually (#110)
- Manual trigger bug fix for action publish and sync (#111)
- Fix issue with only first member of a multi-member gz file being ungzipped (#27)  * Fix issue with only first member of a multi-member gz file being ungzipped  * change version
- [cds-977] add pprof to default otel config (#112)
- cds-979: Add integration test for ELB log (#28)  * cargo  * initial test add  * removed metadata label for s3csv  * add elb gz log  * update loglevel
- Fix region typo US --> US1 (#33)  * Fix typo in region selection option in template  * Update README.md  * Update CHANGELOG.md  * Update version  * align cargo.toml version with template version  * Update README.md  * Update README.md  * Update template.yaml  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- S3 archive update role for metrics bucket [CDS-982] (#113)
- Update sync action to add messages in the readme and template files in the CF (#34)  * remove duplicated kinesis option  * Update sync.yml to private messages
- fix a bug with the sync (#35)
- [cds-740] Add MSK and Kafka Support (#36)  * add kafka to cargo.tom  * simplify comebined event serialization  * added kafka_logs process fn  * added kafka test  * template initial commit  * added MSK integration type  * changelog  * added kafka integration type test  * added integration tests for base64  * added support for msk and kafka to cfn template  * updated README with kafka and msk details  * added option to parse base64 kafka values  * added kafka integration type  * added base64 parsing to dependencies  * mdox formatting  * Update src/process.rs  Co-authored-by: Roman Timushev <rtimush@gmail.com>  * add parameter group for kafka and msk  * added MSK and Kafka to list of support services, merged kafka and msk configiruation sections  * update dependencies  ---------  Co-authored-by: Roman Timushev <rtimush@gmail.com>
- adjust rule condition (#43)
- cds-740 fix template (#44)  * update template version and adjust kafka/msk param grouping  * align cargo.toml version with template version  * adjust condition  * removed validation from comaseparated list parameters  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- change kafka param types (#45)
- v0.0.12 (#46)
- cds-740 fix kafka-event bug (#48)  * re-added kinesis event type and adjusted kafka event handle  * adjusted all tests to ensure that they call the deserializer, removed internal reverence to underlying types.  * change log  * adjust comments  * Add default to subsystem param  * Updated version  * align cargo.toml version with template version  ---------  Co-authored-by: royfur <121816837+royfur@users.noreply.github.com> Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Adding Feature ECR Image Scan Report (#49)  New ECR Image Scan Event Support added.  ---------  Co-authored-by: Rafał Sumisławski <rafal.sumislawski@coralogix.com> Co-authored-by: royfur <121816837+royfur@users.noreply.github.com>
- v0.0.14 release (#50)  * Update CHANGELOG.md  * Update template.yaml  * align cargo.toml version with template version  ---------  Co-authored-by: Concourse <42734517+coralogix-concourse@users.noreply.github.com>
- Deprecation notice athena-s3#Node16-Deprecation
- adjust the name of the pr that the sync action create (#114)
- Update Status to GA v1.0.0
- remove old integrations from the sync (#115)
- Deprecation Notice for all nodejs16 integration
- move the aws-shipper lambda in the sync to shared folder (#116)
- Remove jest and update dependencies in resource-metadata
- OTEL Agent security mount vol scope (#117)
- cds-719 fix rc workflow
- set default ecs-ec2 otel to log level warn (#119)
- [CDS-1060] Add ses:sendmail policy to use sender identity
- [CDS-1060] semantic version missing
- cds-1050 - add x86 lambda support
- V 1.0.1
- allow sync to run manually from master
- Cds 863
- fix vulnerability in dependencies #2
- Update README.md (#120)
- fix ecs ec2 default config (#121)
- fix mount ecs ec2 (#122)
- cds-1099  add recomine configuration to default ecs-ec2 otel configuration (#123)
- Set Force Flush value to 0 in ecs-ec2 otel (#124)
- Fix bug related to EcrScan integration trigger
- Update sync action to allow the created template to retrieve secrets (#125)
- Update lambda manager code to add permission for each log group [CDS-1136]
- V1.0.3
- Create a new module to create role that will be used my metrics integration (#127)
- cds-756 Add DLQ Support to Shipper Lambda
- Remove ECS-EC2 Deprecated cfn template parameter (#126)
- Add one more permission to policy in coralogix-metrics-integration (#128)
- allow log groups with / to trigger lambda [CDS-1191]
- Fix Runtime issues in Amazon Linux 2 by Updating to AmazonLinux 2023
- fix url enconde key name
- Sync issue (#130)
- trigger the sync action (#131)
- fix url enconde key name
- update github action version (#132)
- set metrics type aggregations as default (#134)
- v1.0.7
- update the code for the sync action to work in case template has output section (#135)
- Update sync action to avoid vulnerability [INFOSEC-347] (#136)
- cds-1235 Remove ANSI characters from logs and update to Parameter description
- Add Command line to the MSK integration [CDS-1248]
- cds-1241 Add Validation for Docker logs for  default Otel Config  (#137)
- Add more permissions to archive for delete, and interchanged ap1 and ap2 regions [FASTV2-1262] (#138)
- Update URL for Us2 (#139)
- minor documentation updates
- changlog
- updated hardcoded image version in template

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)