### PR TITLE
cds-1304 Added Command Flag to ECS-EC2 otel task definition

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+### 0.0.14 / 2024-06-09
+- Added config flag to ecs-ec2 task definition
+
 ### 0.0.13 / 2024-05-21
 - Update US2 URL
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -467,6 +467,7 @@ Resources:
         - Name: coralogix-otel-agent
           Cpu: 0
           Memory: !Ref Memory
+          Command: ["--config", "env:OTEL_CONFIG"]
           Image: !If
             - UseImage
             - !Ref Image
@@ -549,6 +550,7 @@ Resources:
         - Name: coralogix-otel-agent
           Cpu: 0
           Memory: !Ref Memory
+          Command: ["--config", "env:OTEL_CONFIG"]
           Image: !If
             - UseImage
             - !Ref Image


### PR DESCRIPTION
Due to config changes in upstream otel, `--config <value>` flags are now being enforced explicitly, even though the value in our case is read from the ENV variable.

- Added command to task definition: `--config env:OTEL_CONFIG`
