### PR TITLE
Update ENV Vars in embedded Otel Config

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+### 0.0.14 / 2024-08-28
+- Adjusted how ENV variables are set in the ECS-EC2 embedded otel config,`$VAR` has been deprecated in favor of `${VAR}`
+- Updated README to reflect that as of `v0.3.0` decoding base64 encoded env variables is not supported.
+- Added `account-` prefix to account ID default subsystem name in embedded otel config to fix issue with this value being interpreted as a float during unmarshalling in otel.
+
 ### 0.0.14 / 2024-06-09
 - Added config flag to ecs-ec2 task definition
 

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -9,22 +9,22 @@ CloudFormation template to launch the Coralogix Distribution for Open Telemetry 
 <!--
 'solution' vs 'example'. We are as a team already supporting this repo. What should be our actual support posture? If this repo is positioned as "supported" by CX? Then:'This solution', is more accurate than:'This example'.
 -->
+
 This example uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
 
-The OTEL collector/agent/daemon image used is the [Coralogix Distribution for Open Telemetry](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector) Docker Hub image. It is deployed as a [_Daemon_](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon) ECS Task, i.e. one OTEL collector agent container on each EC2 instance (i.e. ECS container instance) across the cluster.
+The OTEL collector/agent/daemon image used is the [Coralogix Distribution for Open Telemetry](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector) Docker Hub image. It is deployed as a [*Daemon*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon) ECS Task, i.e. one OTEL collector agent container on each EC2 instance (i.e. ECS container instance) across the cluster.
 
 CDOT extends upon the main [Open Telemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) project, adding features specifically to enhance integration with AWS ECS, among other improvements.
 
-The OTEL agent is deployed as a Daemon ECS Task and connected using [```host``` network mode](https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-networkmode-host.html). OTEL-instrumented application containers that need to send telemetry to the local OTEL agent can lookup the IP address of the CDOT container [using a number of methods](https://coralogix.com/docs/opentelemetry-using-ecs-ec2/#otel-agent-network-service-discovery), making it easier for Application Tasks using ```awsvpc``` and ```bridge``` network modes to connect with the OTEL agent. OTEL-instrumented application containers should also consider which resource attributes to use as telemetry identifiers.
+The OTEL agent is deployed as a Daemon ECS Task and connected using [`host` network mode](https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-networkmode-host.html). OTEL-instrumented application containers that need to send telemetry to the local OTEL agent can lookup the IP address of the CDOT container [using a number of methods](https://coralogix.com/docs/opentelemetry-using-ecs-ec2/#otel-agent-network-service-discovery), making it easier for Application Tasks using `awsvpc` and `bridge` network modes to connect with the OTEL agent. OTEL-instrumented application containers should also consider which resource attributes to use as telemetry identifiers.
 
 The CDOT OTEL agent also features enhancements specific to ECS integration. These improvements are proprietary to the Coralogix Distribution for Open Telemetry.
 
 ### Logs
 
-The OTEL agent uses a [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filereceiver) to read the docker logs of all containers on the EC2 host. OTLP is also accepted. Coralogix provides the ```awsecscontainermetricsd``` receiver which enables metrics collection of all tasks on the same host. The [coralogix exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter) forwards telemetry to your configured Coralogix endpoint.
+The OTEL agent uses a [filelog receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filereceiver) to read the docker logs of all containers on the EC2 host. OTLP is also accepted. Coralogix provides the `awsecscontainermetricsd` receiver which enables metrics collection of all tasks on the same host. The [coralogix exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/coralogixexporter) forwards telemetry to your configured Coralogix endpoint.
 
-Logs are collected from all containers that log to `/var/lib/docker/containers/*/*.log`.
-The container requires privileges to mount the host read-only file path `/var/lib/docker/`.
+Logs are collected from all containers that log to `/var/lib/docker/containers/*/*.log`. The container requires privileges to mount the host read-only file path `/var/lib/docker/`.
 
 ### Metrics
 
@@ -41,17 +41,17 @@ A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the lo
 
 ## Parameters:
 
-| Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                                | Required           |
-|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
-| ClusterName      | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                              | :heavy_check_mark: |
-| CDOTImageVersion | The Coralogix Open Telemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                              |                    |
-| Memory           | The amount of memory to allocate to the Open Telemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                          |                    |
-| CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:* <br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- US1<br>- US2   | :heavy_check_mark: |
-| ApplicationName  | You application name                                                                                                                                                                                                                 |                                                                              | :heavy_check_mark: |
-| SubsystemName    | You Subsystem name                                                                                                                                                                                                                   | AWS Account ID                                                               | :heavy_check_mark: |
-| CoralogixApiKey | The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/ |                                                                              | :heavy_check_mark: |
-| Metrics          | Enable/Disable Metrics                                                                                                                                                                                                               | disable                                                                      |                    |
-| OtelConfig       | The Base64 encoded Open Telemetry configuration yaml to use. This parameter allows you to pass your own Open Telemetry configuration. This will be used instead of the embedded configuration if specified.                          |                                                                              |                    |
+| Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                            | Required           |
+|------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|--------------------|
+| ClusterName      | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                          | :heavy_check_mark: |
+| CDOTImageVersion | The Coralogix Open Telemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                          |                    |
+| Memory           | The amount of memory to allocate to the Open Telemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                      |                    |
+| CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:* <br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- US1<br>- US2 | :heavy_check_mark: |
+| ApplicationName  | You application name                                                                                                                                                                                                                 |                                                                          | :heavy_check_mark: |
+| SubsystemName    | You Subsystem name                                                                                                                                                                                                                   | AWS Account ID                                                           | :heavy_check_mark: |
+| CoralogixApiKey  | The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/                                                                                                                       |                                                                          | :heavy_check_mark: |
+| Metrics          | Enable/Disable Metrics                                                                                                                                                                                                               | disable                                                                  |                    |
+| OtelConfig       | The Open Telemetry Configuration Yaml string. This will be used instead of the embedded configuration if specified.<br>**Note** that as of image `v0.3.0` decoding base64 encoded env variables, is no longer supporter.             |                                                                          |                    |
 
 ## Deploy the Cloudformation template:
 
@@ -76,7 +76,7 @@ aws cloudformation deploy --template-file cfn_template.yaml --stack-name <stack_
         ClusterName=<ecs cluster name> \
         CDOTImageVersion=<image tag> \
         CoralogixApiKey=<your-private-key> \
-        OtelConfig=$(cat path/to/otelconfig.yaml | base64) \
+        OtelConfig=$(cat path/to/otelconfig.yaml) \
         CoralogixRegion=<coralogix-region>
 ```
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -185,13 +185,11 @@ Mappings:
             override: false
 
         exporters:
-          logging:
-            verbosity: detailed
           coralogix:
-            domain: "$CORALOGIX_DOMAIN"
-            private_key: "$PRIVATE_KEY"
-            application_name: "$APP_NAME"
-            subsystem_name: "$SUB_SYS"
+            domain: "${CORALOGIX_DOMAIN}"
+            private_key: "${PRIVATE_KEY}"
+            application_name: "${APP_NAME}"
+            subsystem_name: "${SUB_SYS}"
             application_name_attributes:
             - "aws.ecs.cluster"
             - "aws.ecs.cluster.name"
@@ -339,12 +337,11 @@ Mappings:
             override: false
 
         exporters:
-          logging:
           coralogix:
-            domain: "$CORALOGIX_DOMAIN"
-            private_key: "$PRIVATE_KEY"
-            application_name: "$APP_NAME"
-            subsystem_name: "$SUB_SYS"
+            domain: "${CORALOGIX_DOMAIN}"
+            private_key: "${PRIVATE_KEY}"
+            application_name: "${APP_NAME}"
+            subsystem_name: "${SUB_SYS}"
             application_name_attributes:
             - "aws.ecs.cluster"
             - "aws.ecs.cluster.name"
@@ -520,7 +517,7 @@ Resources:
             - Name: SUB_SYS
               Value: !If
                 - UseDefaultSubsystemName
-                - !Sub "${AWS::AccountId}"
+                - !Sub "account-${AWS::AccountId}"
                 - !Ref DefaultSubsystemName
 
             - Name: OTEL_CONFIG
@@ -594,7 +591,7 @@ Resources:
             - Name: SUB_SYS
               Value: !If
                 - UseDefaultSubsystemName
-                - !Sub "${AWS::AccountId}"
+                - !Sub "account-${AWS::AccountId}"
                 - !Ref DefaultSubsystemName
 
             - Name: OTEL_CONFIG


### PR DESCRIPTION
- Adjusted how ENV variables are set in the ECS-EC2 embedded otel config,`$VAR` has been deprecated in favor of `${VAR}`
- Updated README to reflect that as of `v0.3.0` decoding base64 encoded env variables is not supported.
- Added `account-` prefix to account ID default subsystem name in embedded otel config to fix issue with this value being interpreted as a float during unmarshalling in otel.
