### PR TITLE
[MAJOR][BREAKING] Added logging pipeline to OTEL ECS-Fargate integration documentation.

### DIFF
--- a/aws-integrations/ecs-fargate/CHANGELOG.md
+++ b/aws-integrations/ecs-fargate/CHANGELOG.md
@@ -5,8 +5,11 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
-### 0.0.4 / 2024-09-02
+### 0.0.5 / 2024-09-11
 ### 🛑 Breaking changes 🛑
+* [UPDATE] Update ecs-fargate integration cf template to OTEL only (remove fluentbit logrouter)
+
+### 0.0.4 / 2024-09-02
 * [UPDATE] Update domains to follow [coralogix-domain](coralogix.com/docs/coralogix-domain) and added AP3
 
 ### 0.0.3 / 2024-06-26

--- a/aws-integrations/ecs-fargate/README.md
+++ b/aws-integrations/ecs-fargate/README.md
@@ -1,12 +1,9 @@
 # ECS Fargate APM integrations
 
-## ECS Fargate Logs
-Logs are collected using a sidecar deployment of [aws-for-fluent-bit](https://github.com/aws/aws-for-fluent-bit) as a firelens log_router.
+## Note: This ECS Fargate integration used to require the use of fluentbit logrouter for logs processing. This version does everything within OTEL.
 
-Details of this integration can be found [here](https://github.com/coralogix/telemetry-shippers/tree/master/logs/fluent-bit/ecs-fargate)
-
-## ECS Fargate Traces and Metrics
-Traces and Metrics are collected using Opentelemetry Collector Contrib.
+## ECS Fargate Logs, Metrics and Traces
+Logs, Metrics and Traces are collected using Opentelemetry Collector Contrib.
 
 Details of this integration can be found [here](https://github.com/coralogix/telemetry-shippers/blob/master/otel-ecs-fargate/README.md)
 
@@ -27,7 +24,6 @@ It does demonstrate which permissions are required, at a minimum, to deploy our 
 |-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------|--------------------|
 | PrivateKey      | Your Coralogix Private Key                                                                                                                                                                                                           |                                                                              | :heavy_check_mark: |
 | CoralogixRegion | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:*<br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- AP3<br>- US1<br>- US2 | :heavy_check_mark: |
-| S3ConfigARN      | The S3 ARN for your uploaded Coralogix Fluent Bit configuration file (Explained in the ECS Fargate Logs integration documentation above)                                                                                                                                                                                                           |                                                                              | :heavy_check_mark: |
 
 
 ### Deploy the Cloudformation template:
@@ -40,5 +36,4 @@ aws cloudformation deploy --template-file ecs-fargate-cf.yaml \
     --parameter-overrides \
         PrivateKey=<your-private-key> \
         CoralogixRegion=<coralogix-region> \
-        S3ConfigARN=<ARN of S3 Config>
 ```

--- a/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
+++ b/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
@@ -15,9 +15,6 @@ Parameters:
     Type: String
     Description: The Coralogix Send-Your-Data API Key which is used to validate your authenticity
     NoEcho: true
-  S3ConfigARN:
-    Type: String
-    Description: The S3 ARN for your uploaded Coralogix Fluent Bit configuration file
 
 Mappings:
   CoralogixRegionMap:
@@ -69,11 +66,42 @@ Resources:
             subsystem_name_attributes:
             - service.name
             - aws.ecs.docker.name
+            - container_name
             timeout: 30s
             traces:
               headers:
                 X-Coralogix-Distribution: ecs-fargate-integration/0.0.1
         processors:
+          transform/firelens:
+            log_statements:
+              - context: log
+                statements:
+                  # parse json logs
+                  - merge_maps(cache, ParseJSON(body), "insert") where IsMatch(body, "^\\{")
+                  # set message
+                  - set(body, cache["message"]) where cache["message"] != nil
+
+                  # set trace/span id
+                  - set(trace_id.string, cache["trace_id"]) where cache["trace_id"] != nil
+                  - set(span_id.string, cache["span_id"]) where cache["span_id"] != nil
+
+                  # set severity when available
+                  - set(severity_number, SEVERITY_NUMBER_INFO) where IsMatch(cache["level"], "(?i)info")
+                  - set(severity_number, SEVERITY_NUMBER_WARN) where IsMatch(cache["level"], "(?i)warn")
+                  - set(severity_number, SEVERITY_NUMBER_ERROR) where IsMatch(cache["level"], "(?i)err")
+                  - set(severity_number, SEVERITY_NUMBER_DEBUG) where IsMatch(cache["level"], "(?i)debug")
+                  - set(severity_number, SEVERITY_NUMBER_TRACE) where IsMatch(cache["level"], "(?i)trace")
+                  - set(severity_number, cache["severity_number"])  where cache["severity_number"] != nil
+
+                  # move log_record attributes to resource
+                  - set(resource.attributes["container_name"], attributes["container_name"])
+                  - set(resource.attributes["container_id"], attributes["container_id"])
+                  - delete_key(attributes, "container_id")
+                  - delete_key(attributes, "container_name")
+
+                  - delete_matching_keys(cache, "^(message|trace_id|span_id|severity_number)$")
+
+                  - merge_maps(attributes,cache, "insert")
           batch:
             send_batch_max_size: 2048
             send_batch_size: 1024
@@ -91,6 +119,9 @@ Resources:
             override: true
             timeout: 2s
         receivers:
+          fluentforward/socket:
+            # ECS will send logs to this socket
+            endpoint: unix:///var/run/fluent.sock
           awsecscontainermetrics:
             collection_interval: 10s
           otlp:
@@ -109,6 +140,16 @@ Resources:
                   - 127.0.0.1:8888
         service:
           pipelines:
+            logs:
+              exporters:
+              - coralogix
+              processors:
+              - transform/firelens
+              - resource/metadata
+              - resourcedetection
+              - batch
+              receivers:
+              - fluentforward/socket
             metrics:
               exporters:
               - coralogix
@@ -159,15 +200,7 @@ Resources:
           LogConfiguration:
             LogDriver: awsfirelens
             Options:
-              Format: json_lines
-              Header: !Sub "Authorization Bearer ${PrivateKey}"
-              Host: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Endpoint]
-              Name: http
-              Port: "443"
-              Retry_Limit: "10"
-              TLS: On
-              URI: /logs/v1/singles
-              Compress: gzip
+              Name: OpenTelemetry
         - Name: otel-collector
           Image: otel/opentelemetry-collector-contrib
           Cpu: 0
@@ -193,35 +226,9 @@ Resources:
           LogConfiguration:
             LogDriver: awsfirelens
             Options:
-              Format: json_lines
-              Header: !Sub "Authorization Bearer ${PrivateKey}"
-              Host: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Endpoint]
-              Name: http
-              Port: "443"
-              Retry_Limit: "10"
-              TLS: On
-              URI: /logs/v1/singles
-              Compress: gzip
-        - Name: log_router
-          Image: public.ecr.aws/aws-observability/aws-for-fluent-bit:init-2.31.12
-          Cpu: 0
-          Essential: false
-          Environment:
-            - Name: aws_fluent_bit_init_s3_1
-              Value: !Ref S3ConfigARN
-          MountPoints: []
-          VolumesFrom: []
-          User: "0"
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-create-group: "true"
-              awslogs-group: /ecs/Coralogix-observability
-              awslogs-region: !Ref AWS::Region
-              awslogs-stream-prefix: log_router
+              Name: OpenTelemetry
           FirelensConfiguration:
             Type: fluentbit
-            Options: {}
 
       RequiresCompatibilities:
         - FARGATE


### PR DESCRIPTION
# Description

Updated our ECS-Fargate integration to process logs using OTEL instead of needing fluentbit as well.

# How Has This Been Tested?

CF template was deployed into AWS lab account and task definition launched as service. Observed logs and metrics arriving at CX platform.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)