### PR TITLE
Add validation to parameters in cloudwatch-metrics integration policy

### DIFF
--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### - rename ExternalId to ExternalIdSecret
 #### - Add validation to ExternalIdSecret, must be a valid pattern of [\w+=,.:\/-]*
 #### - Add validation to CustomerAccountId, must be a valid pattern of [0-9]*
+#### - rename CustomerAccountId to CustomAccountId
 
 ### 6.9.2024
 ### New permission for ECS enhanced monitoring

--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## AwsMetrics
 
+### 15.9.2024
+### braking changes:
+#### - rename ExternalId to ExternalIdSecret
+#### - Add validation to ExternalIdSecret, must be a valid pattern of [\w+=,.:\/-]*
+#### - Add validation to CustomerAccountId, must be a valid pattern of [0-9]*
+
 ### 6.9.2024
 ### New permission for ECS enhanced monitoring
 

--- a/coralogix-policies/coralogix-metrics-integration-policy/README.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/README.md
@@ -8,5 +8,5 @@ The module will create a role to be used with AwsMetrics integration
 |-----------|-------------|---------------|----------|
 | AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, dev, staging, custom] | EU1 | :heavy_check_mark: |
 | RoleName | The name of the rule that template will create in your AWS account | n\a | :heavy_check_mark: |
-| CustomerAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |
-| ExternalId | "sts:ExternalId" this id is used for increased security | n\a | :heavy_check_mark: |
+| CustomAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |
+| ExternalIdSecret | "sts:ExternalId" this id is used for increased security | n\a | :heavy_check_mark: |

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -62,7 +62,7 @@ Mappings:
       ID: 000000000000
       RoleSuffix: custom
 Conditions:
-  IsCustomAccountId: !Not [!Equals [!Ref CustomerAccountId, ""]]
+  IsCustomAccountId: !Not [!Equals [!Ref CustomAccountId, ""]]
 Resources:
   CoralogixAwsMetricsRole:
     Type: AWS::IAM::Role
@@ -78,7 +78,7 @@ Resources:
                 - "arn:aws:iam::${aws_account_id}:role/coralogix-ingestion-${role_suffix}"
                 - aws_account_id: !If
                     - IsCustomAccountId
-                    - !Ref CustomerAccountId
+                    - !Ref CustomAccountId
                     - !FindInMap [CoralogixEnvironment, !Ref AWSAccount, "ID"]
                   role_suffix: !FindInMap [CoralogixEnvironment, !Ref AWSAccount, "RoleSuffix"]
             Action:
@@ -90,7 +90,7 @@ Resources:
                   - ExternalIdSecret: !Ref ExternalIdSecret
                     account_id: !If
                       - IsCustomAccountId
-                      - !Ref CustomerAccountId
+                      - !Ref CustomAccountId
                       - !FindInMap [CoralogixEnvironment, !Ref AWSAccount, "ID"]
       Policies:
         - PolicyName: CoralogixMetricsPolicy

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -1,9 +1,10 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: The module will create a role with an inline policy to allow Coralogix to send events to an EventBridge event bus.
 Parameters:
-  ExternalId:
-    Description: "ExternalId for sts:AssumeRole"
+  ExternalIdSecret:
+    Description: "ExternalIdSecret for sts:AssumeRole"
     Type: "String"
+    AllowedPattern: "[\\w+=,.:\\/-]*"
   AWSAccount:
     Type: String
     Default: EU1
@@ -22,10 +23,11 @@ Parameters:
   RoleName:
     Type: String
     Description: The name of the role that will be created.
-  CustomerAccountId:
+  CustomAccountId:
     Type: String
     Description: Custom AWS account ID that you want to deploy the integration in.
     Default: ""
+    AllowedPattern: "[0-9]*"
 
 Mappings:
   CoralogixEnvironment:
@@ -83,7 +85,13 @@ Resources:
               - sts:AssumeRole
             Condition:
               StringEquals:
-                sts:ExternalId: !Ref ExternalId
+                sts:ExternalId: !Sub
+                  - "${ExternalIdSecret}@${account_id}"
+                  - ExternalIdSecret: !Ref ExternalIdSecret
+                    account_id: !If
+                      - IsCustomAccountId
+                      - !Ref CustomerAccountId
+                      - !FindInMap [CoralogixEnvironment, !Ref AWSAccount, "ID"]
       Policies:
         - PolicyName: CoralogixMetricsPolicy
           PolicyDocument:


### PR DESCRIPTION
# Description
- Add validation to variables: ExternalIdSecret, CustomAccountId
- Rename variables:
ExternalId --> ExternalIdSecret
CustomerAccountId --> CustomAccountId
- Change ExternalId format to be of structure  ExternalIdSecret@AWSAccount

[CDS-1522]
<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)