### PR TITLE
Another permission for RDS enhanced monitoring

### DIFF
--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## AwsMetrics
 
+### 25.9.2024
+### New permission to be able to get RDS and EC2 instance metadata like allocated memmory, CPU, etc.
+
 ### 6.9.2024
 ### New permission for ECS enhanced monitoring
 

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -102,6 +102,7 @@ Resources:
                   - dms:DescribeReplicationTasks
                   - ec2:DescribeTransitGatewayAttachments
                   - ec2:DescribeSpotFleetRequests
+                  - ec2:DescribeInstanceTypes
                   - storagegateway:ListGateways
                   - storagegateway:ListTagsForResource
                   - rds:Describe*


### PR DESCRIPTION
# Description

New permission to be able to get RDS and EC2 instance metadata like allocated memmory, CPU, etc.

# How Has This Been Tested?

In aws UI

# Checklist:
- [x] I have updated the relevant component changelog(s)