### PR TITLE
LUM-450 add staging assume role permissions for resource catalog

### DIFF
--- a/coralogix-policies/coralogix-resource-catalog-role/CHANGELOG.md
+++ b/coralogix-policies/coralogix-resource-catalog-role/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## resource catalog
 
+### 0.0.4 / 02.10.2024
+* [update] Add staging and lumos-research to environments
+* 
+
 ### 0.0.3 / 30.9.2024
 * [update] Add ec2:DescribeNetworkInterfaces
 * 

--- a/coralogix-policies/coralogix-resource-catalog-role/template.yaml
+++ b/coralogix-policies/coralogix-resource-catalog-role/template.yaml
@@ -6,6 +6,8 @@ Parameters:
     Default: EU1
     Description: The Coralogix region that your account is in.
     AllowedValues:
+      - EU1_STG
+      - EU1_LUM
       - EU1
       - EU2
       - AP1
@@ -27,6 +29,12 @@ Parameters:
     Default: ""
 Mappings:
   CoralogixEnvironment:
+    EU1_STG:
+      ID: 233221153619
+      CxEnvId: stg1
+    EU1_LUM:
+      ID: 311141556446
+      CxEnvId: lumos-research
     EU1:
       ID: 625240141681
       CxEnvId: production
@@ -55,7 +63,7 @@ Conditions:
   IsCustomAccountId: !Not [!Equals [!Ref CustomAccountId, ""]]
   IsCustomCoralogixEnvId: !Not [!Equals [!Ref CustomCoralogixEnvId, ""]]
 Resources:
-  CoralogixAwsMetricsRole:
+  CoralogixResourceCatalogRole:
     Type: AWS::IAM::Role
     Properties:
       Description: "Role to allow coralogix to describe ec2"


### PR DESCRIPTION
# Description

- add staging and lumos-research environment assume role permissions for resource catalog
- Fix resource naming to be more descriptive

<!-- Please describe the changes you made in a few words or sentences. -->
We need staging to be in the list of allowed Coralogix AWS environments
Fixes https://coralogix.atlassian.net/browse/LUM-450
<!-- (provide issue number, if applicable; otherwise remove) --> 
# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)