### PR TITLE
Fix rds:ListTagsForResource permission name

### DIFF
--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## AwsMetrics
 
+### 18.10.2024
+### Fix rds:ListTagsForResource permission
+
 ### 30.9.2024
 ### Make the policy more secure by adding more specific permissions and not using `*` in the policy
 
 ### 25.9.2024
-### New permission to be able to get RDS and EC2 instance metadata like allocated memmory, CPU, etc.
+### New permission to be able to get RDS and EC2 instance metadata like allocated memory, CPU, etc.
 
 ### 6.9.2024
 ### New permission for ECS enhanced monitoring

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -107,7 +107,7 @@ Resources:
                   - storagegateway:ListTagsForResource
                   - rds:DescribeDbInstances
                   - rds:DescribeReservedDbInstances
-                  - rds:ListListTagsForResource
+                  - rds:ListTagsForResource
                   - ecs:ListClusters
                   - ecs:DescribeClusters
                   - ecs:ListServices


### PR DESCRIPTION
# Description

Fix permission name in the metrics integration policy.

Fixes #163

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)