### PR TITLE
specify grpc as appprotocol in cfn exmaple, needed to properly export…

### DIFF
--- a/aws-integrations/ecs-fargate/CHANGELOG.md
+++ b/aws-integrations/ecs-fargate/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.7 / 2024-10-25
+* [CHANGE] Specify grpc as appProtocol, needed to properly export traces.
+
 ### 0.0.6 / 2024-10-18
 * [UPDATE] Update ecs-fargate integration cf to allow larger "Advanced" Parameter Store.
 * [UPDATE] Adjust roles to true minimum requirements.

--- a/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
+++ b/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
@@ -226,9 +226,11 @@ Resources:
             - ContainerPort: 4317
               HostPort: 4317
               Protocol: tcp
+              AppProtocol: grpc
             - ContainerPort: 4318
               HostPort: 4318
               Protocol: tcp
+              AppProtocol: grpc
           Essential: false
           Command: ["--config", "env:SSM_CONFIG"]
           Environment:


### PR DESCRIPTION
… traces

# Description

During our integration with Coralogix, we were only able to logs, but not able to export traces.

In a call with a Coralogix representative, we were shown example code where the only difference was that appProtocol was specified. It turned out we had copied the example code from this cloudformation template, which didn't specify grpc as appProtocol. After reploying with appprotocol specified, traces started showing up in our Coralogix console.

# How Has This Been Tested?

Solved the issue in our case. I would assume other integrators using the same setup with a sidecar in ECS will also need to specify grpc the same way. Feel free to reject this PR if that is not the case!

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)