### PR TITLE
Add new permissions for Amazon Elasticache to coralogix-metric-integr…

### DIFF
--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -51,3 +51,11 @@
 
 ### 27.11.2024
 ### Fix CustomAccountId field name for custom account and align template description
+
+### 5.12.2024
+### New permissions, that would allow integration to get data from Amazon ElastiCache API
+- Added permissions:
+    ```
+    - elasticache:DescribeCacheClusters
+    - elasticache:ListTagsForResource
+    ```

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -114,6 +114,8 @@ Resources:
                   - ecs:DescribeServices
                   - ecs:ListContainerInstances
                   - ecs:DescribeContainerInstances
+                  -	elasticache:DescribeCacheClusters
+				          - elasticache:ListTagsForResource
                 Resource: "*"
 
 Outputs:


### PR DESCRIPTION
…ation-policy

# Description

New permissions needed for [PIPEV2-2208](https://coralogix.atlassian.net/browse/PIPEV2-2208)

# How Has This Been Tested?

Yes by adding the roles to role in our AWS account

# Checklist:
- [x] I have updated the relevant component changelog(s)