### PR TITLE
Add Cloudformation template for Coralogix Remote Actions policy

### DIFF
--- a/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/CHANGELOG.md
@@ -51,3 +51,6 @@
 
 ### 27.11.2024
 ### Fix CustomAccountId field name for custom account and align template description
+
+### 06.12.2024
+### Remove dev and staging from the available cx environments list

--- a/coralogix-policies/coralogix-metrics-integration-policy/README.md
+++ b/coralogix-policies/coralogix-metrics-integration-policy/README.md
@@ -6,7 +6,7 @@ The module will create a role to be used with AwsMetrics integration
 
 | Parameter | Description | Default Value | Required |
 |-----------|-------------|---------------|----------|
-| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, dev, staging, custom] | EU1 | :heavy_check_mark: |
+| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, custom] | EU1 | :heavy_check_mark: |
 | RoleName | The name of the rule that template will create in your AWS account | n\a | :heavy_check_mark: |
 | CustomAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |
 | ExternalId | "sts:ExternalId" this id is used for increased security | n\a | :heavy_check_mark: |

--- a/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
+++ b/coralogix-policies/coralogix-metrics-integration-policy/template.yaml
@@ -9,8 +9,6 @@ Parameters:
     Default: EU1
     Description: The AWS account that you want to deploy the integration in.
     AllowedValues:
-      - dev
-      - staging
       - EU1
       - EU2
       - AP1
@@ -29,12 +27,6 @@ Parameters:
 
 Mappings:
   CoralogixEnvironment:
-    dev:
-      ID: 233273809180
-      RoleSuffix: dev01
-    staging:
-      ID: 233221153619
-      RoleSuffix: stg1
     EU1:
       ID: 625240141681
       RoleSuffix: eu1

--- a/coralogix-policies/coralogix-remote-actions-policy/CHANGELOG.md
+++ b/coralogix-policies/coralogix-remote-actions-policy/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## CoralogixRemoteActions
+
+### 06.12.2024
+### Add initial version of Coralogix Remote Actions CF template.

--- a/coralogix-policies/coralogix-remote-actions-policy/README.md
+++ b/coralogix-policies/coralogix-remote-actions-policy/README.md
@@ -1,0 +1,18 @@
+# Aws Metrics integration Role
+
+The module will create a role to be used with Coralogix Remote Actions product
+
+## Fields
+
+| Parameter | Description | Default Value | Required |
+|-----------|-------------|---------------|----------|
+| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, dev, staging, custom] | EU1 | :heavy_check_mark: |
+| RoleName | The name of the rule that template will create in your AWS account | n\a | :heavy_check_mark: |
+| CustomAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |
+| ExternalId | "sts:ExternalId" this id is used for increased security | n\a | :heavy_check_mark: |
+
+Run the following command to deploy the integration:
+
+```sh
+aws cloudformation deploy --capabilities CAPABILITY_IAM  CAPABILITY_NAMED_IAM --template-file template.yaml --stack-name <the name of the stack that will be deploy in aws> --parameter-overrides AWSAccount=<coralogix account region> RoleName=<RoleName> ExternalId=<ExternalId>
+```

--- a/coralogix-policies/coralogix-remote-actions-policy/README.md
+++ b/coralogix-policies/coralogix-remote-actions-policy/README.md
@@ -6,7 +6,7 @@ The module will create a role to be used with Coralogix Remote Actions product
 
 | Parameter | Description | Default Value | Required |
 |-----------|-------------|---------------|----------|
-| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, dev, staging, custom] | EU1 | :heavy_check_mark: |
+| AWSAccount | The Alias for the Coralogix region, possible options are [US1, US2, EU1, EU2, AP1, AP2, AP3, custom] | EU1 | :heavy_check_mark: |
 | RoleName | The name of the rule that template will create in your AWS account | n\a | :heavy_check_mark: |
 | CustomAccountId | In case you want to use a custom coralogix account, enter the aws account id that you want to use.| n\a  | |
 | ExternalId | "sts:ExternalId" this id is used for increased security | n\a | :heavy_check_mark: |

--- a/coralogix-policies/coralogix-remote-actions-policy/template.yaml
+++ b/coralogix-policies/coralogix-remote-actions-policy/template.yaml
@@ -1,0 +1,104 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: The module will create a role with an inline policy to allow Coralogix to execute custom actions remotely.
+Parameters:
+  AwsAccountId:
+    Description: "Aws Account id"
+    Type: "String"
+  ExternalId:
+    Description: "ExternalId for sts:AssumeRole"
+    Type: "String"
+  CoralogixRegion:
+    Type: String
+    Default: EU1
+    Description: The AWS account that you want to deploy the integration in.
+    AllowedValues:
+      - dev
+      - staging
+      - EU1
+      - EU2
+      - AP1
+      - AP2
+      - AP3
+      - US1
+      - US2
+      - CustomEndpoint
+  RoleName:
+    Type: String
+    Description: The name of the role that will be created.
+  CustomAccountId:
+    Type: String
+    Description: Custom AWS account ID that you want to deploy the integration in.
+    Default: ""
+
+Mappings:
+  CoralogixEnvironment:
+    dev:
+      ID: 233273809180
+      RoleSuffix: dev01
+    staging:
+      ID: 233221153619
+      RoleSuffix: stg1
+    EU1:
+      ID: 625240141681
+      RoleSuffix: eu1
+    EU2:
+      ID: 625240141681
+      RoleSuffix: eu2
+    AP1:
+      ID: 625240141681
+      RoleSuffix: ap1
+    AP2:
+      ID: 625240141681
+      RoleSuffix: ap2
+    AP3:
+      ID: 025066248247
+      RoleSuffix: ap3
+    US1:
+      ID: 625240141681
+      RoleSuffix: us1
+    US2:
+      ID: 739076534691
+      RoleSuffix: us2
+    CustomEndpoint:
+      ID: 000000000000
+      RoleSuffix: custom
+Conditions:
+  IsCustomAccountId: !Not [!Equals [!Ref CustomAccountId, ""]]
+Resources:
+  CoralogixRemoteActionRole:
+    Type: AWS::IAM::Role
+    DeletionPolicy: Retain
+    Properties:
+      Description: description
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "arn:aws:iam::${aws_account_id}:role/coralogix-remote-actions-${role_suffix}"
+                - aws_account_id: !If
+                    - IsCustomAccountId
+                    - !Ref CustomAccountId
+                    - !FindInMap [ CoralogixEnvironment, !Ref CoralogixRegion, "ID" ]
+                  role_suffix: !FindInMap [ CoralogixEnvironment, !Ref CoralogixRegion, "RoleSuffix" ]
+            Action:
+              - sts:AssumeRole
+            Condition:
+              StringEquals:
+                sts:ExternalId: !Ref ExternalId
+      Policies:
+        - PolicyName: CoralogixEc2Policy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:RebootInstances
+                Resource: "*"
+
+Outputs:
+  CoralogixRemoteActionRoleArn:
+    Description: The ARN of the Coralogix remote actions role.
+    Value: !GetAtt CoralogixRemoteActionRole.Arn

--- a/coralogix-policies/coralogix-remote-actions-policy/template.yaml
+++ b/coralogix-policies/coralogix-remote-actions-policy/template.yaml
@@ -12,8 +12,6 @@ Parameters:
     Default: EU1
     Description: The AWS account that you want to deploy the integration in.
     AllowedValues:
-      - dev
-      - staging
       - EU1
       - EU2
       - AP1
@@ -32,12 +30,6 @@ Parameters:
 
 Mappings:
   CoralogixEnvironment:
-    dev:
-      ID: 233273809180
-      RoleSuffix: dev01
-    staging:
-      ID: 233221153619
-      RoleSuffix: stg1
     EU1:
       ID: 625240141681
       RoleSuffix: eu1


### PR DESCRIPTION
# Description

Adding Cloudformation template for creating role necessary for Coralogix Remote Actions feature.

https://coralogix.atlassian.net/browse/VTX-7934

# How Has This Been Tested?
By running cloudformation template in the testing account.

# Checklist:
- [ x ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)