### PR TITLE
fix: CDS-1747 get rid of IAM permissions for shipper custom resource function

### DIFF
--- a/aws-integrations/aws-shipper-lambda/CHANGELOG.md
+++ b/aws-integrations/aws-shipper-lambda/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### v1.1.1 / 2025-12-27
+### 🧰 Bug fixes 🧰
+- cds-1747 - Removed `iam:*` permissions from Shipper, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly
+
 ### v1.1.0 / 2025-12-11
 ### 💡 Enhancements (Breaking) 💡
 - cds-1705 - updated support for dynamic value allocation of Application and Subsystem names based on internal metadata

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1090,12 +1090,9 @@ Resources:
             - Sid: EventSourceMappings
               Effect: Allow
               Action:
-                - lambda:ListEventSourceMappings
                 - lambda:CreateEventSourceMapping
                 - lambda:DeleteEventSourceMapping
                 - lambda:UpdateEventSourceMapping
-                - lambda:GetFunctionConfiguration
-                - lambda:UpdateFunctionConfiguration
               Resource: '*'
         - Statement:
             - Sid: S3NotificationPolicy

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1070,12 +1070,6 @@ Resources:
       Timeout: 900
       Policies:
         - Statement:
-            - Sid: IAMaccess
-              Effect: Allow
-              Action:
-                - 'iam:*'
-              Resource: '*'
-        - Statement:
             - Sid: EC2Access
               Effect: Allow
               Action:

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1090,9 +1090,12 @@ Resources:
             - Sid: EventSourceMappings
               Effect: Allow
               Action:
+                - lambda:ListEventSourceMappings
                 - lambda:CreateEventSourceMapping
                 - lambda:DeleteEventSourceMapping
                 - lambda:UpdateEventSourceMapping
+                - lambda:GetFunctionConfiguration
+                - lambda:UpdateFunctionConfiguration
               Resource: '*'
         - Statement:
             - Sid: S3NotificationPolicy


### PR DESCRIPTION
# Description

This will remove `iam:*` permissions from Shipper cloudformation template, as they were leftover from older versions as the Custom Resource use to be responsible for editing the policy directly

Fixes CDS-1747 (partially)

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)