### PR TITLE
Ecs ec2 update - CDS-1735

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -7,8 +7,9 @@
 
 ### 0.0.16 / 2025-01-14
 ### 🛑 Breaking changes 🛑
-- Adjusted default deployment to have single configuration with instructions to comment out unwanted sections vs numerous alternate configuration toggles/logic.
-- Replaced Custom plaintext Configuration mechanism with Parameter Store as CF template variables can only be 4096 characters which was insufficient for many custom configurations.
+- Adjusted embeded configuration to support logs/metrics and traces by default.
+- Added support for resource catalog.
+- Replaced Custom plaintext Configuration mechanism with Parameter Store as CF template parameters can only be 4096 bypes which was insufficient for many custom configurations.
 - Added AP3 Region.
 
 ### 0.0.15 / 2024-12-19

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🛑 Breaking changes 🛑
 - Adjusted default deployment to have single configuration with instructions to comment out unwanted sections vs numerous alternate configuration toggles/logic.
 - Replaced Custom plaintext Configuration mechanism with Parameter Store as CF template variables can only be 4096 characters which was insufficient for many custom configurations.
+- Added AP3 Region.
 
 ### 0.0.15 / 2024-12-19
 - Removed the line from Opentelemetry config which caused the agent to fail

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,7 +5,7 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
-### 0.0.16 / 2025-01-14
+### 1.0.0 / 2025-01-14
 ### 🛑 Breaking changes 🛑
 - Adjusted embeded configuration to support logs/metrics and traces by default.
 - Added support for resource catalog.

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## opentelemetry ecs-ec2
+<!-- To add a new entry write: -->
+<!-- ### version / full date -->
+<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 0.0.16 / 2025-01-14
+### 🛑 Breaking changes 🛑
+- Adjusted default deployment to have single configuration with instructions to comment out unwanted sections vs numerous alternate configuration toggles/logic.
+- Replaced Custom plaintext Configuration mechanism with Parameter Store as CF template variables can only be 4096 characters which was insufficient for many custom configurations.
+
 ### 0.0.15 / 2024-12-19
 - Removed the line from Opentelemetry config which caused the agent to fail
 
@@ -34,11 +44,6 @@
 
 ### 0.0.7 / 2024-02-23
 - Updated ECS EC2 default Otel configuration to log level warn.
-
-## opentelemetry ecs-ec2
-<!-- To add a new entry write: -->
-<!-- ### version / full date -->
-<!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
 ### 0.0.6 / 2024-02-13
 - [update],[otel]: Restrict mount vol scope; enable metrics otlp; enable batch with defaults. Soft-deprecate previous cx region codes for replacements; Hard-deprecate param name `PrivateKey` for `CoralogixApiKey`; Readme content sync with terraform version, formatting.

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -1,20 +1,20 @@
 # Coralogix OpenTelemetry Agent for ECS-EC2. Cloudformation template.
 
-This CloudFormation template deploys an ECS Service and Task Definition for running the Open Telemetry agent on an ECS Cluster. This deployment is able to collect Logs, Metrics and Traces. The template will deploy a daemonset which runs an instance open telemetry on each node in a cluster.
+This CloudFormation template deploys an ECS Service and Task Definition for running the OpenTelemetry Collector agent on an ECS Cluster. This deployment is able to collect Logs, Metrics and Traces. The template will deploy a daemonset which runs an instance of OpenTelemetry Collector on each node in a cluster.
 
-CloudFormation template to launch the Coralogix Distribution for Open Telemetry ("CDOT") into an existing ECS Cluster. This CDOT deployment is able to collect Logs, Metrics and Traces. CDOT is deployed in the OTEL [Agent deployment](https://opentelemetry.io/docs/collector/deployment/agent/) pattern, as an ECS Daemon Service type, which runs an instance of the Open Telemetry collector agent on each node in a cluster.
+CloudFormation template to launch the Coralogix Distribution for OpenTelemetry ("CDOT") into an existing ECS Cluster. This CDOT deployment is able to collect Logs, Metrics and Traces. CDOT is deployed in the OTEL [Agent deployment](https://opentelemetry.io/docs/collector/deployment/agent/) pattern, as an ECS Daemon Service type, which runs an instance of the OpenTelemetry Collector agent on each node in a cluster.
 
 ## Image
 
-This solution uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of Open Telemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
+This solution uses the coralogixrepo/coralogix-otel-collector image which is a custom distribution of OpenTelemetry containing custom components developed by Coralogix. The image is available on [Docker Hub](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector). The ECS components are described [here](./components.md)
 
-The OTEL collector/agent/daemon image used is the [Coralogix Distribution for Open Telemetry](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector) Docker Hub image. It is deployed as a [*Daemon*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon) ECS Task, i.e. one OTEL collector agent container on each EC2 instance (i.e. ECS container instance) across the cluster.
+The OTEL Collector/agent/daemon image used is the [Coralogix Distribution for OpenTelemetry](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector) Docker Hub image. It is deployed as a [*Daemon*](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_services.html#service_scheduler_daemon) ECS Task, i.e. one OTEL Collector agent container on each EC2 instance (i.e. ECS container instance) across the cluster.
 
-CDOT extends upon the main [Open Telemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) project, adding features specifically to enhance integration with AWS ECS, among other improvements.
+CDOT extends upon the main [OpenTelemetry Collector Contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) project, adding features specifically to enhance integration with AWS ECS, among other improvements.
 
 The OTEL agent is deployed as a Daemon ECS Task and connected using [`host` network mode](https://docs.aws.amazon.com/AmazonECS/latest/bestpracticesguide/networking-networkmode-host.html). OTEL-instrumented application containers that need to send telemetry to the local OTEL agent can lookup the IP address of the CDOT container [using a number of methods](https://coralogix.com/docs/opentelemetry-using-ecs-ec2/#otel-agent-network-service-discovery), making it easier for Application Tasks using `awsvpc` and `bridge` network modes to connect with the OTEL agent. OTEL-instrumented application containers should also consider which resource attributes to use as telemetry identifiers.
 
-The CDOT OTEL agent also features enhancements specific to ECS integration. These improvements are proprietary to the Coralogix Distribution for Open Telemetry.
+The CDOT OTEL agent also features enhancements specific to ECS integration. These improvements are proprietary to the Coralogix Distribution for OpenTelemetry.
 
 ### Logs
 
@@ -26,9 +26,9 @@ Logs are collected from all containers that log to `/var/lib/docker/containers/*
 
 Container metrics are collected from all containers running on the ECS Cluster. The metrics are collected using the [awsecscontainermetricsd](./components.md#awsecscontainermetricsd) receiver. If you do not wish to collect container metrics, comment out or delete the `metrics/containermetrics` pipeline from the configuration.
 
-### Open Telemetry Collector Metrics
+### OpenTelemetry Collector Metrics
 
-The default configuration exposes opentelemetry collector metrics on port `8888` via the path `/metrics`. The metrics are collected using a [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) scrape job. These are performance metrics of the opentelemetry collector containers. Records received and processed, submission faults and more.
+The default configuration exposes OpenTelemetry Collector metrics on port `8888` via the path `/metrics`. The metrics are collected using a [prometheus](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) scrape job. These are performance metrics of the OpenTelemetry Collector containers. Records received and processed, submission faults and more.
 
 ### Traces
 
@@ -44,13 +44,15 @@ A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the lo
 | Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                            | Required           |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|--------------------|
 | ClusterName      | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                          | :heavy_check_mark: |
-| CDOTImageVersion | The Coralogix Open Telemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                          |                    |
-| Memory           | The amount of memory to allocate to the Open Telemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                      |                    |
-| CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:* <br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- US1<br>- US2 | :heavy_check_mark: |
+| CDOTImageVersion | The Coralogix OpenTelemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                          |                    |
+| Memory           | The amount of memory to allocate to the OpenTelemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                      |                    |
+| CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:* <br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- AP3<br>- US1<br>- US2 | :heavy_check_mark: |
 | ApplicationName  | Your application name                                                                                                                                                                                                                 |                                                                          | :heavy_check_mark: |
 | SubsystemName    | Your Subsystem name |                                                            | :heavy_check_mark: |
 | CoralogixApiKey  | The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/                                                                                                                       |                                                                          | :heavy_check_mark: |
 | CustomConfig       | The name of a Parameter Store to use as a custom configuration. Must be in the same region as your ECS cluster.            | none                                                                         |                    |
+| TaskExecutionRoleARN       |       When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.            | Default                                                                        |                    |
+
 
 ## Deploy the Cloudformation template:
 
@@ -59,13 +61,13 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
     --region <region> \
     --parameter-overrides \
         DefaultApplicationName=<application name> \
-        CDOTImageVersion=<image tag> \
         ClusterName=<ecs cluster name> \
+        CDOTImageVersion=<image tag> \
         CoralogixApiKey=<your-private-key> \
         CoralogixRegion=<coralogix-region>
 ```
 
-**When using a custom configuration for Open Telemetry**
+**When using a custom configuration for OpenTelemetry**
 
 ```sh
 aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
@@ -75,19 +77,20 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
         ClusterName=<ecs cluster name> \
         CDOTImageVersion=<image tag> \
         CoralogixApiKey=<your-private-key> \
+        CoralogixRegion=<coralogix-region> \
         CustomConfig=<Parameter Store Name> \
-        CoralogixRegion=<coralogix-region>
+        TaskExecutionRoleARN=<task-execution-role-arn>
 ```
 
 Note that these are just examples of how this could be deployed. You can also deploy this template using the AWS Console or any Cloudformation management tools.
 
-### Open Telemetry Configuration
+### OpenTelemetry Configuration
 
-The Open Telemetry configuration is embedded in this cloudformation template by default, however, you do have the option of specifying your own configuration using the `CustomConfig` parameter. When using a custom configuration, you must ensure your EC2 host has access to the AWS Systems Manager API and the OTEL containers have read permission for the specified Parameter Store.
+An OpenTelemetry configuration is embedded in the cloudformation template by default, however, you do have the option of specifying your own configuration, stored in a Parameter Store, using the `CustomConfig` parameter. When using a custom configuration, you must ensure your EC2 host has access to the AWS Systems Manager API and the OTEL containers have read permission for the specified Parameter Store. You will need to create a task execution role with those permissions and align it using the `TaskExecutionRoleARN` parameter.
 
-The default configuration will monitor container logs, listen for traces on port `4317/4318`, and monitor container metrics using the `awsecscontainermetricsd` receiver which is based on the [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) receiver, however, instead of monitoring a single task, metrics will be collected from all containers. If you do not wish to collect container metrics, simply comment out or delete the metrics/containermetrics pipeline from the configuration.
+The default configuration will monitor container logs, listen for logs, metrics and traces on port `4317/4318`, and monitor container metrics using the `awsecscontainermetricsd` receiver. The `awsecscontainermetricsd` receiver is based on the [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) receiver, however, instead of monitoring a single task, metrics will be collected from all containers. If you do not wish to collect container metrics, comment out or delete the metrics/container-metrics pipeline from the configuration.
 
-The embeded default Open Telemetry configuration can be viewed [here](./template.yaml#L90).
+The embeded default OpenTelemetry configuration can be viewed [here](./template.yaml#L90).
 
 ### Health Check
 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -1,17 +1,16 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: |
-  The template used to create an Otel ECS Service from on an ECS Console. Logs and Traces
-  are enabled by default. Metrics are disabled by default. To enable metrics, set the
-  Metrics parameter to "enable".
+  Create an OTEL ECS Daemon Service on an ECS Cluster.
 
 Parameters:
   ClusterName:
+    Description: |
+      Name of the ECS Cluster onto which to deploy the OTEL Daemon Service.
     Type: String
 
   CDOTImageVersion:
     Description: |
-      The Coralogix Open Telemetry Distribution Image
-      Version/Tag.
+      The Coralogix Distribution OpenTelemetry Image Version/Tag.
       View available tags here: https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags
     Type: String
   
@@ -32,7 +31,7 @@ Parameters:
 
   CoralogixRegion:
       Type: String
-      Description: "The Coralogix location region [EU1|EU2|AP1|AP2|US1|US2]. Deprecated: [Europe, Europe2, India, Singapore, US, US2]"
+      Description: "The Coralogix location region [EU1|EU2|AP1|AP2|US1|US2]. Deprecated: [Europe, Europe2, India, Singapore, US]"
       AllowedValues:
         - EU1
         - EU2
@@ -48,48 +47,62 @@ Parameters:
 
   DefaultApplicationName:
     Type: String
-    Description: The name of your application
+    Description: |
+      The default name of your application.
+      Default application name will be only be used when no dynamic application name is found, as configured in the Coralogix exporter.
     MinLength: "1"
     MaxLength: "64"
+    Default: "OTEL"
 
   DefaultSubsystemName:
     Type: String
-    Description: The subsystem name of your application
+    Description: |
+      The default subsystem name of your application.
+      Default subsystem name will be only be used when no dynamic application name is found, as configured in the Coralogix exporter.
     MinLength: "1"
     MaxLength: "64"
-    Default: "default"
+    Default: "ECS-EC2"
 
   CoralogixApiKey:
     Type: String
-    Description: "The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/"
+    Description: "The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/user-guides/account-management/api-keys/send-your-data-api-key/"
     NoEcho: true
     AllowedPattern: ".+"
     ConstraintDescription: "API Key required."
 
-  Metrics:
-    Type: String
-    Description: If true, cadivisor will be deployed on each node to collect metrics
-    AllowedValues:
-      - "enable"
-      - "disabled"
-    Default: "disabled"
-
-  OtelConfig:
+  CustomConfig:
     Type: String
     Description: |
-      The base64 encoded opentelemetry configuration string used to start the container.
-      If left as default, the embedded configuration will be used.
+      The name of a Parameter Store to use as a custom configuration.
+      If left as 'none' will use the default configuration from the template.
     Default: "none"
 
+  TaskExecutionRoleARN:
+    Type: String
+    Description: |
+      When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.
+    Default: "Default"
+
 Conditions:
-  UseDefaultSubsystemName: !Equals [ !Ref DefaultSubsystemName, "default" ]
-  Metrics: !Equals [ !Ref Metrics, "enable" ]
   UseImage: !Not [!Equals [ !Ref Image, "none" ]]
+  UseDefaultConfig: !Equals [ !Ref CustomConfig, "none" ]
   UseCustomConfig: 
     Fn::Not: 
-    - !Equals [ !Ref OtelConfig, "none" ]
-  IgnoreCustomConfig: !Equals [ !Ref OtelConfig, "none" ]
+    - !Equals [ !Ref CustomConfig, "none" ]
 
+Rules:
+  ValidateTaskExecutionRole:
+    Assertions:
+      - Assert:
+          Fn::Or:
+            - Fn::Equals:
+                - Ref: CustomConfig
+                - "none"
+            - Fn::Not:
+                - Fn::Equals:
+                    - Ref: TaskExecutionRoleARN
+                    - "Default"
+        AssertDescription: "TaskExecutionRoleARN cannot be 'Default' if CustomConfig is set to a value other than 'none'."
 
 Mappings:
   Otel:
@@ -98,16 +111,16 @@ Mappings:
         receivers:
           otlp:
             protocols:
-              grpc:
-                endpoint: "0.0.0.0:4317"
-              http:
-                endpoint: "0.0.0.0:4318"
+              grpc: { endpoint: 0.0.0.0:4317 }
+              http: { endpoint: 0.0.0.0:4318 }
+
+          awsecscontainermetricsd:
 
           prometheus:
             config:
               scrape_configs:
               - job_name: otel-collector-metrics
-                scrape_interval: 60s
+                scrape_interval: 30s
                 static_configs:
                 - targets: ["localhost:8888"]
 
@@ -117,7 +130,6 @@ Mappings:
             include:
               - /hostfs/var/lib/docker/containers/*/*.log
             include_file_path: true
-            # add log.file.path to resource attributes
             operators:
               - type: router
                 id: docker_log_json_parser
@@ -150,9 +162,28 @@ Mappings:
                 from: attributes["log.file.path"]
                 to: resource["log.file.path"]
 
+          hostmetrics:
+            root_path: /
+            collection_interval: 10s
+            scrapers:
+              cpu: { metrics: { system.cpu.utilization: { enabled: true } } }
+              disk: null
+              filesystem:
+                exclude_fs_types: { fs_types: [autofs, binfmt_misc, bpf, cgroup2, configfs, debugfs, devpts, devtmpfs, fusectl, hugetlbfs, iso9660, mqueue, nsfs, overlay, proc, procfs, pstore, rpc_pipefs, securityfs, selinuxfs, squashfs, sysfs, tracefs], match_type: strict }
+                exclude_mount_points: { match_type: regexp, mount_points: [/dev/*, /proc/*, /sys/*, /run/k3s/containerd/*, /run/containerd/runc/*, /var/lib/docker/*, /var/lib/kubelet/*, /snap/*] }
+              load: null
+              memory: { metrics: { system.memory.utilization: { enabled: true } } }
+              network: null
+              process:
+                metrics:
+                  process.cpu.utilization: { enabled: true }
+                  process.memory.utilization: { enabled: true }
+                  process.threads: { enabled: true }
+                mute_process_exe_error: true
+                mute_process_user_error: true
+
         processors:
           resourcedetection:
-            # ecs & docker detectors not required when using ecslogresourcedetection for logs
             detectors: [env, ec2, system]
             timeout: 2s
             override: false
@@ -172,167 +203,42 @@ Mappings:
                   - set(attributes["image_id"], attributes["image.id"])
                   - delete_key(attributes, "image.id")
 
-          batch:
-            send_batch_size: 1024
-            send_batch_max_size: 2048
-            timeout: "1s"
-
-          # otel-collector resource detection for collector
-          resourcedetection/otel-collector:
-            detectors: [ecs, ec2]
-            timeout: 2s
-            override: false
-
-        exporters:
-          coralogix:
-            domain: "${CORALOGIX_DOMAIN}"
-            private_key: "${PRIVATE_KEY}"
-            application_name: "${APP_NAME}"
-            subsystem_name: "${SUB_SYS}"
-            application_name_attributes:
-            - "aws.ecs.cluster"
-            - "aws.ecs.cluster.name"
-            - "aws.ecs.task.definition.family"
-            subsystem_name_attributes:
-            - "aws.ecs.container.name"
-            - "aws.ecs.docker.name"
-            - "docker.name"
-            timeout: 30s
-
-        extensions:
-          health_check:
-          pprof:
-
-        service:
-          extensions:
-            - health_check
-            - pprof
-
-          pipelines:
-            logs:
-              receivers: 
-                - filelog
-              processors:
-                - resourcedetection
-                - ecsattributes
-                - transform/logs
-              exporters:
-                - coralogix
-
-            traces:
-              receivers:
-                - otlp
-              processors:
-                - batch
-              exporters:
-                - coralogix
-
-            metrics/otel-collector:
-              receivers:
-                - prometheus
-              processors:
-                - resourcedetection/otel-collector
-                - batch
-              exporters:
-                - coralogix
-
-          telemetry:
-            logs:
-              level: warn
-            metrics:
-              address: 0.0.0.0:8888
-              level: detailed
-
-      Metrics: |
-        receivers:
-          otlp:
-            protocols:
-              grpc:
-                endpoint: "0.0.0.0:4317"
-              http:
-                endpoint: "0.0.0.0:4318"
-
-          prometheus:
-            config:
-              scrape_configs:
-              - job_name: otel-collector-metrics
-                scrape_interval: 60s
-                static_configs:
-                - targets: ['localhost:8888']
-
-          filelog:
-            start_at: end
-            force_flush_period: 0
-            include:
-              - /hostfs/var/lib/docker/containers/*/*.log
-            include_file_path: true
-            # add log.file.path to resource attributes
-            operators:
-              - type: router
-                id: docker_log_json_parser
-                routes:
-                  - output: json_parser
-                    expr: 'body matches "^\\{\"log\".*\\}"'
-                default: move_log_file_path
-
-              - type: json_parser
-                parse_from: body
-                parse_to: body
-                output: recombine
-                timestamp:
-                  parse_from: body.time
-                  layout: '%Y-%m-%dT%H:%M:%S.%fZ'
-
-              # handle logs split by docker
-              - type: recombine
-                id: recombine
-                output: move_log_file_path
-                combine_field: body.log
-                source_identifier: attributes["log.file.path"]
-                is_last_entry: body.log endsWith "\n"
-                force_flush_period: 10s	
-                on_error: send
-                combine_with: ""
-
-              - type: move
-                id: move_log_file_path
-                from: attributes["log.file.path"]
-                to: resource["log.file.path"]
-                
-          awsecscontainermetricsd:
-
-        processors:
-          resourcedetection:
-            # ecs & docker detectors not required when using ecslogresourcedetection for logs
-            detectors: [env, ec2, system]
-            timeout: 2s
-            override: false
-
-          ecsattributes:
-            container_id:
-              sources:
-                - "log.file.path"
-
-          transform/logs:
-            error_mode: ignore
+          transform/entity-event:
+            error_mode: silent
             log_statements:
+              - context: log
+                statements:
+                  - set(attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+                  - merge_maps(attributes, resource.attributes, "insert")
               - context: resource
                 statements:
-                  - set(attributes["cx_container_id"], attributes["docker.id"])
-                  - set(attributes["aws_ecs_task_family"], attributes["aws.ecs.task.definition.family"])
-                  - set(attributes["image_id"], attributes["image.id"])
-                  - delete_key(attributes, "image.id")
+                  - keep_keys(attributes, [""])
 
-          batch:
-            send_batch_size: 1024
-            send_batch_max_size: 2048
-            timeout: "1s"
+          batch: { send_batch_max_size: 2048, send_batch_size: 1024, timeout: 1s }
+
+          resource/metadata:
+            attributes:
+              - action: upsert
+                key: cx.otel_integration.name
+                value: coralogix-integration-ecs-ec2
 
           # otel-collector resource detection for collector
           resourcedetection/otel-collector:
-            detectors: [ecs, ec2]
-            timeout: 2s
+            detectors: [system, env, ec2, ecs]
             override: false
+            timeout: 2s
+            system:
+              resource_attributes:
+                host.id: { enabled: false }
+                host.cpu.cache.l2.size: { enabled: true }
+                host.cpu.stepping: { enabled: true }
+                host.cpu.model.name: { enabled: true }
+                host.cpu.model.id: { enabled: true }
+                host.cpu.family: { enabled: true }
+                host.cpu.vendor.id: { enabled: true }
+                host.mac: { enabled: true }
+                host.ip: { enabled: true }
+                os.description: { enabled: true }
 
         exporters:
           coralogix:
@@ -342,14 +248,24 @@ Mappings:
             subsystem_name: "${SUB_SYS}"
             application_name_attributes:
             - "aws.ecs.cluster"
-            - "aws.ecs.cluster.name"
             - "aws.ecs.task.definition.family"
             subsystem_name_attributes:
             - "aws.ecs.container.name"
             - "aws.ecs.docker.name"
             - "docker.name"
             timeout: 30s
-          
+
+          coralogix/resource_catalog:
+            application_name: resource
+            domain: ${CORALOGIX_DOMAIN}
+            private_key: ${PRIVATE_KEY}
+            logs:
+              headers:
+                X-Coralogix-Distribution: ecs-ec2-integration/0.0.1
+                x-coralogix-ingress: metadata-as-otlp-logs/v1alpha1
+            subsystem_name: catalog
+            timeout: 30s
+
         extensions:
           health_check:
           pprof:
@@ -359,42 +275,31 @@ Mappings:
             - health_check
             - pprof
 
-          pipelines:
+          pipelines:            
             logs:
-              receivers: 
-                - filelog
-              processors:
-                - resourcedetection
-                - ecsattributes
-                - transform/logs
-              exporters:
-                - coralogix
+              receivers: [filelog]
+              processors: [resourcedetection, ecsattributes, resource/metadata, transform/logs, batch]
+              exporters: [coralogix]
 
-            metrics:
-              receivers:
-                - otlp
-                - awsecscontainermetricsd
-              processors:
-                - batch
-              exporters:
-                - coralogix
-            
-            traces:
-              receivers:
-                - otlp
-              processors:
-                - batch
-              exporters:
-                - coralogix
+            logs/resource_catalog:
+              receivers: [hostmetrics]
+              processors: [resourcedetection/otel-collector, transform/entity-event, batch]
+              exporters: [coralogix/resource_catalog]
+
+            metrics/containermetrics:
+              receivers: [otlp, awsecscontainermetricsd]
+              processors: [batch]
+              exporters: [coralogix]
 
             metrics/otel-collector:
-              receivers:
-                - prometheus
-              processors:
-                - resourcedetection/otel-collector
-                - batch
-              exporters:
-                - coralogix
+              receivers: [prometheus, hostmetrics]
+              processors: [resourcedetection/otel-collector, resource/metadata, batch]
+              exporters: [coralogix]
+
+            traces:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
+              exporters: [coralogix]
 
           telemetry:
             logs:
@@ -402,7 +307,6 @@ Mappings:
             metrics:
               address: 0.0.0.0:8888
               level: detailed
-
 
   CoralogixRegionMap:
     EU1:
@@ -439,11 +343,10 @@ Mappings:
       Endpoint: ingress.coralogix.us:443
       Domain: coralogix.us
 
-
 Resources:
   OtelTaskDefinition: 
     Type: AWS::ECS::TaskDefinition
-    Condition: IgnoreCustomConfig
+    Condition: UseDefaultConfig
     Properties:
       Family: opentelemetry
       RequiresCompatibilities:
@@ -474,6 +377,7 @@ Resources:
             # otel grpc endpoint
             - HostPort: 4317
               Protocol: tcp
+              AppProtocol: grpc
               ContainerPort: 4317
             
             # otel http endpoint
@@ -513,21 +417,16 @@ Resources:
               Value: !Ref DefaultApplicationName
 
             - Name: SUB_SYS
-              Value: !If
-                - UseDefaultSubsystemName
-                - !Sub "account-${AWS::AccountId}"
-                - !Ref DefaultSubsystemName
+              Value: !Ref DefaultSubsystemName
 
             - Name: OTEL_CONFIG
-              Value: !If
-                - Metrics
-                - !FindInMap [Otel, Config, Metrics]
-                - !FindInMap [Otel, Config, Default]
+              Value: !FindInMap [Otel, Config, Default]
 
   OtelTaskDefinitionCustom: 
     Type: AWS::ECS::TaskDefinition
     Condition: UseCustomConfig
     Properties:
+      ExecutionRoleArn: !Ref TaskExecutionRoleARN
       Family: opentelemetry
       RequiresCompatibilities:
         - EC2
@@ -553,17 +452,26 @@ Resources:
             
           Essential: true
           PortMappings:
+            # otel grpc endpoint
             - HostPort: 4317
               Protocol: tcp
+              AppProtocol: grpc
               ContainerPort: 4317
             
+            # otel http endpoint
             - HostPort: 4318
               Protocol: tcp
               ContainerPort: 4318
 
+            # otel metrics endpoint
             - HostPort: 8888
               Protocol: tcp
               ContainerPort: 8888
+
+            # pprof extension default port
+            - HostPort: 1777
+              Protocol: tcp
+              ContainerPort: 1777
 
           # Privileged required to access certain host metrics
           Privileged: true
@@ -587,17 +495,15 @@ Resources:
               Value: !Ref DefaultApplicationName
 
             - Name: SUB_SYS
-              Value: !If
-                - UseDefaultSubsystemName
-                - !Sub "account-${AWS::AccountId}"
-                - !Ref DefaultSubsystemName
+              Value: !Ref DefaultSubsystemName
 
+          Secrets:
             - Name: OTEL_CONFIG
-              Value: !Ref OtelConfig
+              ValueFrom: !Ref CustomConfig
 
   ECSService:
     Type: 'AWS::ECS::Service'
-    Condition: IgnoreCustomConfig
+    Condition: UseDefaultConfig
     Properties:
       Cluster: !Ref ClusterName
       LaunchType: EC2
@@ -646,4 +552,3 @@ Resources:
           Value: !Ref 'AWS::StackId'
       EnableECSManagedTags: true
       TaskDefinition: !Ref OtelTaskDefinitionCustom
-      

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -267,7 +267,7 @@ Mappings:
             private_key: ${PRIVATE_KEY}
             logs:
               headers:
-                X-Coralogix-Distribution: ecs-ec2-integration/0.0.1
+                X-Coralogix-Distribution: ecs-ec2-integration/1.0.0
                 x-coralogix-ingress: metadata-as-otlp-logs/v1
             subsystem_name: catalog
             timeout: 30s

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -31,19 +31,15 @@ Parameters:
 
   CoralogixRegion:
       Type: String
-      Description: "The Coralogix location region [EU1|EU2|AP1|AP2|US1|US2]. Deprecated: [Europe, Europe2, India, Singapore, US]"
+      Description: "The Coralogix location region [EU1|EU2|AP1|AP2|AP3|US1|US2]]"
       AllowedValues:
         - EU1
         - EU2
         - AP1
         - AP2
+        - AP3
         - US1
         - US2
-        - Europe
-        - Europe2
-        - India
-        - Singapore
-        - US
 
   DefaultApplicationName:
     Type: String
@@ -321,27 +317,15 @@ Mappings:
     AP2:
       Endpoint: ingress.coralogixsg.com:443
       Domain: coralogixsg.com
+    AP3:
+      Endpoint: ingress.ap3.coralogix.com:443
+      Domain: ap3.coralogix.com
     US1:
       Endpoint: ingress.coralogix.us:443
       Domain: coralogix.us
     US2:
       Endpoint: ingress.cx498.coralogix.com:443
       Domain: cx498.coralogix.com
-    Europe:
-      Endpoint: ingress.coralogix.com:443
-      Domain: coralogix.com
-    Europe2:
-      Endpoint: ingress.eu2.coralogix.com:443
-      Domain: eu2.coralogix.com
-    India:
-      Endpoint: ingress.coralogix.in:443
-      Domain: coralogix.in
-    Singapore:
-      Endpoint: ingress.coralogixsg.com:443
-      Domain: coralogixsg.com
-    US:
-      Endpoint: ingress.coralogix.us:443
-      Domain: coralogix.us
 
 Resources:
   OtelTaskDefinition: 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -163,13 +163,10 @@ Mappings:
             collection_interval: 10s
             scrapers:
               cpu: { metrics: { system.cpu.utilization: { enabled: true } } }
-              disk: null
               filesystem:
                 exclude_fs_types: { fs_types: [autofs, binfmt_misc, bpf, cgroup2, configfs, debugfs, devpts, devtmpfs, fusectl, hugetlbfs, iso9660, mqueue, nsfs, overlay, proc, procfs, pstore, rpc_pipefs, securityfs, selinuxfs, squashfs, sysfs, tracefs], match_type: strict }
                 exclude_mount_points: { match_type: regexp, mount_points: [/dev/*, /proc/*, /sys/*, /run/k3s/containerd/*, /run/containerd/runc/*, /var/lib/docker/*, /var/lib/kubelet/*, /snap/*] }
-              load: null
               memory: { metrics: { system.memory.utilization: { enabled: true } } }
-              network: null
               process:
                 metrics:
                   process.cpu.utilization: { enabled: true }
@@ -179,12 +176,7 @@ Mappings:
                 mute_process_user_error: true
 
         processors:
-          resourcedetection:
-            detectors: [env, ec2, system]
-            timeout: 2s
-            override: false
-
-          ecsattributes:
+          ecsattributes/container-logs:
             container_id:
               sources:
                 - "log.file.path"
@@ -236,6 +228,23 @@ Mappings:
                 host.ip: { enabled: true }
                 os.description: { enabled: true }
 
+          resourcedetection/entity:
+            detectors: [system, env, ec2, ecs]
+            override: false
+            timeout: 2s
+            system:
+              resource_attributes:
+                host.id: { enabled: false }
+                host.cpu.cache.l2.size: { enabled: true }
+                host.cpu.stepping: { enabled: true }
+                host.cpu.model.name: { enabled: true }
+                host.cpu.model.id: { enabled: true }
+                host.cpu.family: { enabled: true }
+                host.cpu.vendor.id: { enabled: true }
+                host.mac: { enabled: true }
+                host.ip: { enabled: true }
+                os.description: { enabled: true }
+
         exporters:
           coralogix:
             domain: "${CORALOGIX_DOMAIN}"
@@ -258,7 +267,7 @@ Mappings:
             logs:
               headers:
                 X-Coralogix-Distribution: ecs-ec2-integration/0.0.1
-                x-coralogix-ingress: metadata-as-otlp-logs/v1alpha1
+                x-coralogix-ingress: metadata-as-otlp-logs/v1
             subsystem_name: catalog
             timeout: 30s
 
@@ -272,18 +281,18 @@ Mappings:
             - pprof
 
           pipelines:            
-            logs:
+            logs/container-logs:
               receivers: [filelog]
-              processors: [resourcedetection, ecsattributes, resource/metadata, transform/logs, batch]
+              processors: [ecsattributes/container-logs, resource/metadata, transform/logs, batch]
               exporters: [coralogix]
 
             logs/resource_catalog:
               receivers: [hostmetrics]
-              processors: [resourcedetection/otel-collector, transform/entity-event, batch]
+              processors: [resourcedetection/entity, transform/entity-event, batch]
               exporters: [coralogix/resource_catalog]
 
-            metrics/containermetrics:
-              receivers: [otlp, awsecscontainermetricsd]
+            metrics/container-metrics:
+              receivers: [awsecscontainermetricsd]
               processors: [batch]
               exporters: [coralogix]
 
@@ -292,7 +301,12 @@ Mappings:
               processors: [resourcedetection/otel-collector, resource/metadata, batch]
               exporters: [coralogix]
 
-            traces:
+            metrics/otlp:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
+              exporters: [coralogix]
+
+            traces/otlp:
               receivers: [otlp]
               processors: [resource/metadata, batch]
               exporters: [coralogix]

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -125,6 +125,7 @@ Mappings:
             force_flush_period: 0
             include:
               - /hostfs/var/lib/docker/containers/*/*.log
+            include_file_name: false
             include_file_path: true
             operators:
               - type: router
@@ -212,7 +213,7 @@ Mappings:
 
           # otel-collector resource detection for collector
           resourcedetection/otel-collector:
-            detectors: [system, env, ec2, ecs]
+            detectors: [system, env, ecs, ec2]
             override: false
             timeout: 2s
             system:
@@ -229,7 +230,7 @@ Mappings:
                 os.description: { enabled: true }
 
           resourcedetection/entity:
-            detectors: [system, env, ec2, ecs]
+            detectors: [system, env, ecs, ec2]
             override: false
             timeout: 2s
             system:
@@ -280,25 +281,20 @@ Mappings:
             - health_check
             - pprof
 
-          pipelines:            
+          pipelines:
             logs/container-logs:
               receivers: [filelog]
               processors: [ecsattributes/container-logs, resource/metadata, transform/logs, batch]
               exporters: [coralogix]
-
-            logs/resource_catalog:
-              receivers: [hostmetrics]
-              processors: [resourcedetection/entity, transform/entity-event, batch]
-              exporters: [coralogix/resource_catalog]
 
             metrics/container-metrics:
               receivers: [awsecscontainermetricsd]
               processors: [batch]
               exporters: [coralogix]
 
-            metrics/otel-collector:
-              receivers: [prometheus, hostmetrics]
-              processors: [resourcedetection/otel-collector, resource/metadata, batch]
+            logs/otlp:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
               exporters: [coralogix]
 
             metrics/otlp:
@@ -309,6 +305,16 @@ Mappings:
             traces/otlp:
               receivers: [otlp]
               processors: [resource/metadata, batch]
+              exporters: [coralogix]
+
+            logs/resource_catalog:
+              receivers: [hostmetrics]
+              processors: [resourcedetection/entity, transform/entity-event, batch]
+              exporters: [coralogix/resource_catalog]
+
+            metrics/otel-collector:
+              receivers: [prometheus, hostmetrics]
+              processors: [resourcedetection/otel-collector, resource/metadata, batch]
               exporters: [coralogix]
 
           telemetry:


### PR DESCRIPTION
# Description

ECS EC2 integration was rewritten with _**breaking changes**_ to support Parameter Store custom configurations.
ECS EC2 integration had new pipelines added and tweaked, including Resource Catalog support.

# How Has This Been Tested?

Deployed to ECS cluster with workload task definition running in parallel. Observed logs, metrics and traces arriving at CX.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)