### PR TITLE
[feat] Add head sampling to ecs ec2 cloudformation cds-1971

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 1.0.2 / 2025-03-25
+- Add Head Sampling to traces of the ECS-EC2 integartion to reduce the initial data ingestion, provided parameters to disable and customize.
+
+
 ### 1.0.1 / 2025-03-15
 - Updated default otel config for ECS-EC2 to use new otel collector metric syntax
 - Added transform to remove unneeded labels from metrics added as of otel v0.119.0

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -34,6 +34,13 @@ The default configuration exposes OpenTelemetry Collector metrics on port `8888`
 
 A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the local OTLP endpoint.
 
+By default, traces are sampled at 10% rate using head sampling. Head sampling is a feature that allows you to sample traces at the collection point before any processing occurs. When enabled, it creates a separate pipeline for sampled traces using probabilistic sampling. This helps reduce the volume of traces while maintaining a representative sample.
+
+The sampling configuration can be adjusted using the following parameters:
+- `EnableHeadSampler`: Enable/disable head sampling
+- `SamplerMode`: Choose between proportional, equalizing, or hash_seed sampling modes
+- `SamplingPercentage`: Set the desired sampling rate (0-100%)
+
 ### Requires:
 
 - An existing ECS Cluster
@@ -52,8 +59,9 @@ A GRPC(*4317*) and HTTP(*4318*) endpoint is exposed for sending traces to the lo
 | CoralogixApiKey  | The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/                                                                                                                       |                                                                          | :heavy_check_mark: |
 | CustomConfig       | The name of a Parameter Store to use as a custom configuration. Must be in the same region as your ECS cluster.            | none                                                                         |                    |
 | TaskExecutionRoleARN       |       When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.            | Default                                                                        |                    |
-
-
+| EnableHeadSampler       |       Enable or disable head sampling for traces. When enabled, sampling decisions are made at the collection point before any processing occurs.            | true 
+| SamplerMode       |       The sampling mode to use:<br>**proportional**: Maintains the relative proportion of traces across services.<br>**equalizing**: Attempts to sample equal numbers of traces from each service.<br>**hash_seed**: Uses consistent hashing to ensure the same traces are sampled across restarts.            | proportional 
+| SamplingPercentage       |        The percentage of traces to sample (0-100). A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.            | 10 
 ## Deploy the Cloudformation template:
 
 ```sh

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -83,9 +83,10 @@ Parameters:
     Type: String
     Description: |
       Enable or disable the head sampler for trace sampling.
-      When enabled, traces will be sampled at the head of the pipeline before processing.
-    AllowedValues: [true, false]
-    Default: true
+      When enabled (default), traces will be sampled at the head of the pipeline before processing.
+      Set to "false" to disable sampling and process all traces.
+    AllowedValues: ["true", "false"]
+    Default: "true"
 
   SamplerMode:
     Type: String
@@ -98,12 +99,12 @@ Parameters:
     Default: proportional
 
   SamplingPercentage:
-    Type: Number
+    Type: String
     Description: |
       The percentage of traces to sample (0-100).
-      A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.    Default: 10
-    MinValue: 0
-    MaxValue: 100
+      A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.
+      Default is 10% sampling.
+    Default: "10"
 
 Conditions:
   UseImage: !Not [!Equals [ !Ref Image, "none" ]]
@@ -111,6 +112,10 @@ Conditions:
   UseCustomConfig: 
     Fn::Not: 
     - !Equals [ !Ref CustomConfig, "none" ]
+  DisableHeadSamplerCondition:
+    Fn::Equals:
+      - !Ref EnableHeadSampler
+      - "false"
 
 Rules:
   ValidateTaskExecutionRole:
@@ -128,9 +133,8 @@ Rules:
 
 Mappings:
   Otel:
-    Config:
-      Default: !Sub |
-        ${EnableHeadSampler == "true" ? "connectors:\n  forward/sampled: {}\n" : ""}
+    BaseConfig:
+      Value: |
         receivers:
           otlp:
             protocols:
@@ -249,7 +253,6 @@ Mappings:
 
           
           batch: { send_batch_max_size: 2048, send_batch_size: 1024, timeout: 1s }
-          ${EnableHeadSampler == "true" ? "head_sampler:\n    sampling_percentage: ${SamplingPercentage}\n    mode: ${SamplerMode}\n" : ""}
 
           resource/metadata:
             attributes:
@@ -291,6 +294,11 @@ Mappings:
                 host.mac: { enabled: true }
                 host.ip: { enabled: true }
                 os.description: { enabled: true }
+          
+
+          probabilistic_sampler:
+            sampling_percentage: "${SAMPLING_PERCENTAGE}"
+            mode: "${SAMPLER_MODE}"
 
         exporters:
           coralogix:
@@ -317,7 +325,12 @@ Mappings:
                 x-coralogix-ingress: metadata-as-otlp-logs/v1
             subsystem_name: catalog
             timeout: 30s
+            
+        connectors:
+          forward/sampled: {}
 
+    PipelineWithSampling:
+      Value: |
         extensions:
           health_check:
           pprof:
@@ -351,12 +364,71 @@ Mappings:
             traces/otlp:
               receivers: [otlp]
               processors: [resource/metadata, batch]
-              exporters: [${EnableHeadSampler == "true" ? "forward/sampled" : "coralogix"}]
-
-            ${EnableHeadSampler == "true" ? "traces/sampled:
+              exporters: [forward/sampled]
+              
+            traces/sampled:
               receivers: [forward/sampled]
-              processors: [head_sampler, batch]
-              exporters: [coralogix]" : ""}
+              processors: [probabilistic_sampler, batch]
+              exporters: [coralogix]
+
+            logs/resource_catalog:
+              receivers: [hostmetrics]
+              processors: [resourcedetection/entity, transform/entity-event, batch]
+              exporters: [coralogix/resource_catalog]
+
+            metrics/otel-collector:
+              receivers: [prometheus, hostmetrics]
+              processors: [resourcedetection/otel-collector, resource/metadata, transform/prometheus, batch]
+              exporters: [coralogix]
+
+          telemetry:
+            logs:
+              level: warn
+
+            metrics:
+              readers:
+                - pull:
+                    exporter:
+                      prometheus:
+                        host: 0.0.0.0
+                        port: 8888
+    
+    PipelinesWithoutSampling:
+      Value: |
+        extensions:
+          health_check: {}
+          pprof: {}
+
+        service:
+          extensions:
+            - health_check
+            - pprof
+
+          pipelines:
+            logs/container-logs:
+              receivers: [filelog]
+              processors: [ecsattributes/container-logs, resource/metadata, transform/logs, batch]
+              exporters: [coralogix]
+
+            metrics/container-metrics:
+              receivers: [awsecscontainermetricsd]
+              processors: [batch]
+              exporters: [coralogix]
+
+            logs/otlp:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
+              exporters: [coralogix]
+
+            metrics/otlp:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
+              exporters: [coralogix]
+
+            traces/otlp:
+              receivers: [otlp]
+              processors: [resource/metadata, batch]
+              exporters: [coralogix]
 
             logs/resource_catalog:
               receivers: [hostmetrics]
@@ -478,9 +550,30 @@ Resources:
 
             - Name: SUB_SYS
               Value: !Ref DefaultSubsystemName
+              
+            - Name: SAMPLING_PERCENTAGE
+              Value: !Ref SamplingPercentage
+
+            - Name: SAMPLER_MODE
+              Value: !Ref SamplerMode
 
             - Name: OTEL_CONFIG
-              Value: !FindInMap [Otel, Config, Default]
+              Value: !If
+                - DisableHeadSamplerCondition
+                - !Sub
+                  - |
+                    ${BaseConfig}
+                    ${PipelinesDef}
+                  - 
+                    BaseConfig: !FindInMap [Otel, BaseConfig, Value]
+                    PipelinesDef: !FindInMap [Otel, PipelinesWithoutSampling, Value]
+                - !Sub
+                  - |
+                    ${BaseConfig}
+                    ${PipelinesDef}
+                  -
+                    BaseConfig: !FindInMap [Otel, BaseConfig, Value]
+                    PipelinesDef: !FindInMap [Otel, PipelineWithSampling, Value]
 
   OtelTaskDefinitionCustom: 
     Type: AWS::ECS::TaskDefinition
@@ -556,6 +649,12 @@ Resources:
 
             - Name: SUB_SYS
               Value: !Ref DefaultSubsystemName
+              
+            - Name: SAMPLING_PERCENTAGE
+              Value: !Ref SamplingPercentage
+
+            - Name: SAMPLER_MODE
+              Value: !Ref SamplerMode
 
           Secrets:
             - Name: OTEL_CONFIG

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -79,6 +79,32 @@ Parameters:
       When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.
     Default: "Default"
 
+  EnableHeadSampler:
+    Type: String
+    Description: |
+      Enable or disable the head sampler for trace sampling.
+      When enabled, traces will be sampled at the head of the pipeline before processing.
+    AllowedValues: [true, false]
+    Default: true
+
+  SamplerMode:
+    Type: String
+    Description: |
+      The sampling mode to use for the head sampler.
+      - proportional: Sample traces at a fixed percentage
+      - equalizing: Dynamically adjust sampling rate to achieve a desired throughput
+      - hash_seed: Use consistent sampling based on a hash of trace attributes
+    AllowedValues: [proportional, equalizing, hash_seed]
+    Default: proportional
+
+  SamplingPercentage:
+    Type: Number
+    Description: |
+      The percentage of traces to sample (0-100).
+      A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.    Default: 10
+    MinValue: 0
+    MaxValue: 100
+
 Conditions:
   UseImage: !Not [!Equals [ !Ref Image, "none" ]]
   UseDefaultConfig: !Equals [ !Ref CustomConfig, "none" ]
@@ -103,7 +129,8 @@ Rules:
 Mappings:
   Otel:
     Config:
-      Default: |
+      Default: !Sub |
+        ${EnableHeadSampler == "true" ? "connectors:\n  forward/sampled: {}\n" : ""}
         receivers:
           otlp:
             protocols:
@@ -222,6 +249,7 @@ Mappings:
 
           
           batch: { send_batch_max_size: 2048, send_batch_size: 1024, timeout: 1s }
+          ${EnableHeadSampler == "true" ? "head_sampler:\n    sampling_percentage: ${SamplingPercentage}\n    mode: ${SamplerMode}\n" : ""}
 
           resource/metadata:
             attributes:
@@ -323,7 +351,12 @@ Mappings:
             traces/otlp:
               receivers: [otlp]
               processors: [resource/metadata, batch]
-              exporters: [coralogix]
+              exporters: [${EnableHeadSampler == "true" ? "forward/sampled" : "coralogix"}]
+
+            ${EnableHeadSampler == "true" ? "traces/sampled:
+              receivers: [forward/sampled]
+              processors: [head_sampler, batch]
+              exporters: [coralogix]" : ""}
 
             logs/resource_catalog:
               receivers: [hostmetrics]


### PR DESCRIPTION
# Description

Added Head Sampling (probabilistic_sampler) with default sampling of 10% and default proportional mode and new variables to disable it or update sampling values.

[CDS-1971](https://coralogix.atlassian.net/browse/CDS-1971)

# How Has This Been Tested?

Deployed the otel agent with default settings, deployed using updated settings, deployed using disabled setting.

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

[CDS-1971]: https://coralogix.atlassian.net/browse/CDS-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ