### PR TITLE
[feat]: Added head sampling to fargate ECS-EC2 integration CDS-1971 

### DIFF
--- a/aws-integrations/ecs-fargate/CHANGELOG.md
+++ b/aws-integrations/ecs-fargate/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 0.0.8 / 2025-25-03
+* [UPDATE] Added head sampling to reduce the initial data ingestion.
+
 ### 0.0.7 / 2024-12-02
 * [FIX] Rename Parameter Store to prevent deployment failure.
 * [UPDATE] Update and flatten configuration to reduce size.

--- a/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
+++ b/aws-integrations/ecs-fargate/ecs-fargate-cf.yaml
@@ -64,6 +64,9 @@ Resources:
       Description: Configuration parameter for Coralogix OTEL Collector
       Type: String
       Value: |
+        connectors:
+          forward/sampled: {}
+
         receivers:
           fluentforward/socket: { endpoint: unix:///var/run/fluent.sock }
           awsecscontainermetrics: { collection_interval: 10s }
@@ -120,6 +123,9 @@ Resources:
                   - delete_matching_keys(cache, "^(message|trace_id|span_id|severity_number)$")
                   - merge_maps(attributes, cache, "insert")
           batch: { send_batch_max_size: 2048, send_batch_size: 1024, timeout: 1s }
+          probabilistic_sampler:
+            sampling_percentage: 10
+            mode: proportional
           resource/metadata:
             attributes:
               - action: upsert
@@ -189,9 +195,13 @@ Resources:
               processors: [resource/metadata, resourcedetection, batch]
               receivers: [otlp, awsecscontainermetrics, prometheus, hostmetrics]
             traces:
-              exporters: [coralogix]
+              exporters: [forward/sampled]
               processors: [resource/metadata, resourcedetection, batch]
               receivers: [otlp]
+            traces/sampled:
+              receivers: [forward/sampled]
+              processors: [probabilistic_sampler, batch]
+              exporters: [coralogix]
           telemetry:
             logs: { level: "warn", encoding: json }
             metrics: { address: 0.0.0.0:8888 }


### PR DESCRIPTION
# Description

Added Head Sampling (probabilistic_sampler) with default sampling of 10% and default proportional mode and new variables to disable it or update sampling values.

[CDS-1971](https://coralogix.atlassian.net/browse/CDS-1971)

# How Has This Been Tested?

Deployed the otel agent with default settings, deployed using updated settings, deployed using disabled setting.

# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

[CDS-1971]: https://coralogix.atlassian.net/browse/CDS-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ