### PR TITLE
[firehose-logs|metrics] Normalize buffering hints with TF and docs

### DIFF
--- a/aws-integrations/firehose-logs/CHANGELOG.md
+++ b/aws-integrations/firehose-logs/CHANGELOG.md
@@ -39,3 +39,6 @@
 ### 🛑 Breaking changes 🛑
 * [Update] Update ingress domain from ingress-firehose.<domain.com>/firehose to ingress.<domain.com>/aws/firehose
 * [Update] Update regions to follow [coralogix.com/docs/coralogix-domain] and added AP3 domain
+
+### 0.0.6 / 03 April 2025
+* [Update] Update buffer size to 1MB to be in line with documentation

--- a/aws-integrations/firehose-logs/template.yaml
+++ b/aws-integrations/firehose-logs/template.yaml
@@ -269,7 +269,7 @@ Resources:
             Ref: DeliveryStreamLogStream
         BufferingHints:
           IntervalInSeconds: 60
-          SizeInMBs: 6
+          SizeInMBs: 1
         RetryOptions:
           DurationInSeconds: 300
         S3BackupMode: FailedDataOnly

--- a/aws-integrations/firehose-metrics/CHANGELOG.md
+++ b/aws-integrations/firehose-metrics/CHANGELOG.md
@@ -42,3 +42,6 @@
 ### 🛑 Breaking changes 🛑
 * [Update] Update ingress domain from ingress-firehose.<domain.com>/firehose to ingress.<domain.com>/aws/firehose
 * [Update] Update regions to follow [coralogix.com/docs/coralogix-domain] and added AP3 domain
+
+### 0.0.7 / 03 April 2025
+* [Update] Update buffer size to 1MB to be in line with documentation

--- a/aws-integrations/firehose-metrics/template.yaml
+++ b/aws-integrations/firehose-metrics/template.yaml
@@ -344,13 +344,13 @@ Resources:
           IntervalInSeconds: 60
           SizeInMBs: 1
         RetryOptions:
-          DurationInSeconds: 30
+          DurationInSeconds: 300
         S3BackupMode: FailedDataOnly
         S3Configuration:
           BufferingHints:
             IntervalInSeconds: 300
             SizeInMBs: 5
-          BucketARN: 
+          BucketARN:
             !GetAtt BackupDataBucket.Arn
           CompressionFormat: GZIP
           RoleARN:


### PR DESCRIPTION
# Description

Related to these two
* https://github.com/coralogix/terraform-coralogix-aws/pull/229
* https://github.com/coralogix/documentation/pull/681

# How Has This Been Tested?

No need to test allowed values are 1 to 64MiB

# Checklist:
- [x] I have updated the relevant component changelog(s)

Open question, we add versions just in changelog and that is it @coralogix/team-cs-devops realised it only now that I never did more in this repo.