### PR TITLE
fix: remove base64 encode from windows otel_config

### DIFF
--- a/opentelemetry/ecs-ec2-windows/template.yaml
+++ b/opentelemetry/ecs-ec2-windows/template.yaml
@@ -135,8 +135,7 @@ Resources:
               Value: !Ref SubsystemName
             
             - Name: "OTEL_CONFIG"
-              Value: 
-                Fn::Base64: |
+              Value: |
                   receivers:
                     awsecscontainermetricsd:
                       sidecar: true
@@ -171,7 +170,7 @@ Resources:
                     batch:
 
                   exporters:
-                    logging:
+                    debug:
                       verbosity: detailed
                     coralogix:
                       domain: "$CORALOGIX_DOMAIN"

--- a/opentelemetry/ecs-ec2-windows/template.yaml
+++ b/opentelemetry/ecs-ec2-windows/template.yaml
@@ -136,78 +136,78 @@ Resources:
             
             - Name: "OTEL_CONFIG"
               Value: |
-                  receivers:
-                    awsecscontainermetricsd:
-                      sidecar: true
+                receivers:
+                  awsecscontainermetricsd:
+                    sidecar: true
 
-                    prometheus:
-                      config:
-                        scrape_configs:
-                          - job_name: otel-collector-metrics
-                            scrape_interval: 30s
-                            static_configs:
-                              - targets: ["localhost:8888"]
+                  prometheus:
+                    config:
+                      scrape_configs:
+                        - job_name: otel-collector-metrics
+                          scrape_interval: 30s
+                          static_configs:
+                            - targets: ["localhost:8888"]
 
-                  processors:
-                    # remove unneeded labels from metrics added as of otel v0.119.0
-                    transform/prometheus:
-                      error_mode: ignore
-                      metric_statements:
-                        - context: metric
-                          statements:
-                            - replace_pattern(name, "_total$", "")
-                        - context: datapoint
-                          statements:
-                            - delete_key(attributes, "otel_scope_name") where resource.attributes["service.name"] == "cdot"
-                            - delete_key(attributes, "service.name") where resource.attributes["service.name"] == "cdot"
+                processors:
+                  # remove unneeded labels from metrics added as of otel v0.119.0
+                  transform/prometheus:
+                    error_mode: ignore
+                    metric_statements:
+                      - context: metric
+                        statements:
+                          - replace_pattern(name, "_total$", "")
+                      - context: datapoint
+                        statements:
+                          - delete_key(attributes, "otel_scope_name") where resource.attributes["service.name"] == "cdot"
+                          - delete_key(attributes, "service.name") where resource.attributes["service.name"] == "cdot"
 
-                        - context: resource
-                          statements:
-                            - delete_key(attributes, "service.instance.id") where attributes["service.name"] == "cdot"
-                            - delete_key(attributes, "service.name") where attributes["service.name"] == "cdot"
+                      - context: resource
+                        statements:
+                          - delete_key(attributes, "service.instance.id") where attributes["service.name"] == "cdot"
+                          - delete_key(attributes, "service.name") where attributes["service.name"] == "cdot"
 
 
-                    batch:
+                  batch:
 
-                  exporters:
-                    debug:
-                      verbosity: detailed
-                    coralogix:
-                      domain: "$CORALOGIX_DOMAIN"
-                      private_key: "$PRIVATE_KEY"
-                      application_name: "otel-collector-windows"
-                      subsystem_name: "ecs"
-                      application_name_attributes:
-                      - $ApplicationName
-                      - "container.name"
-                      subsystem_name_attributes:
-                      - $SubSystemName
-                      - "aws.ecs.task.family"
-                      timeout: 30s
+                exporters:
+                  debug:
+                    verbosity: detailed
+                  coralogix:
+                    domain: "${CORALOGIX_DOMAIN}"
+                    private_key: "${PRIVATE_KEY}"
+                    application_name: "otel-collector-windows"
+                    subsystem_name: "ecs"
+                    application_name_attributes:
+                    - $ApplicationName
+                    - "container.name"
+                    subsystem_name_attributes:
+                    - $SubSystemName
+                    - "aws.ecs.task.family"
+                    timeout: 30s
 
-                  service:
-                    telemetry:
-                      logs:
-                        level: warn
+                service:
+                  telemetry:
+                    logs:
+                      level: warn
 
-                      metrics:
-                        readers:
-                          - pull:
-                              exporter:
-                                prometheus:
-                                  host: 0.0.0.0
-                                  port: 8888
+                    metrics:
+                      readers:
+                        - pull:
+                            exporter:
+                              prometheus:
+                                host: 0.0.0.0
+                                port: 8888
 
-                    pipelines:
-                      metrics:
-                        receivers:
-                          - awsecscontainermetricsd
-                          - prometheus
-                        processors:
-                          - transform/prometheus
-                          - batch
-                        exporters:
-                          - coralogix
+                  pipelines:
+                    metrics:
+                      receivers:
+                        - awsecscontainermetricsd
+                        - prometheus
+                      processors:
+                        - transform/prometheus
+                        - batch
+                      exporters:
+                        - coralogix
 
 
         ### --- your app task definition goes here --- ###


### PR DESCRIPTION
# Description

Update windows cloudformation template, removed base64 encoding as it is not supported and modified logging exporter.


# Checklist:
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)