### PR TITLE
[FEAT] - Add support for new healthcheck binary in coralogix otel CDS-2147

### DIFF
--- a/opentelemetry/ecs-ec2-windows/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2-windows/CHANGELOG.md
@@ -4,6 +4,8 @@
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+### 1.0.3 / 2025-05-20
+- Added healthcheck to ECS task.
 
 ### 0.0.3 / 2025-3-31
 * Add command  `--config env:OTEL_CONFIG` to the windows otel collector container example

--- a/opentelemetry/ecs-ec2-windows/README.md
+++ b/opentelemetry/ecs-ec2-windows/README.md
@@ -25,7 +25,7 @@ This template section provides an example template for deploying the Open Teleme
 | HealthCheckInterval    | Health check interval (seconds)             | 30      |          |
 | HealthCheckTimeout     | Health check timeout (seconds)              | 5       |          |
 | HealthCheckRetries     | Health check retries                        | 3       |          |
-| HealthCheckStartPeriod | Health check start period (seconds)         | 10      |          |
+| HealthCheckStartPeriod | Health check start period (seconds)         | 60      |          |
 
 
 
@@ -54,7 +54,7 @@ You can enable and customize the ECS container health check for the OTEL agent c
 - `HealthCheckInterval` (default: 30)
 - `HealthCheckTimeout` (default: 5)
 - `HealthCheckRetries` (default: 3)
-- `HealthCheckStartPeriod` (default: 10)
+- `HealthCheckStartPeriod` (default: 60)
 
 Example deployment with custom health check settings:
 
@@ -73,7 +73,7 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
         HealthCheckInterval=60 \
         HealthCheckTimeout=10 \
         HealthCheckRetries=5 \
-        HealthCheckStartPeriod=20
+        HealthCheckStartPeriod=60
 ```
 
 ### Image

--- a/opentelemetry/ecs-ec2-windows/README.md
+++ b/opentelemetry/ecs-ec2-windows/README.md
@@ -1,7 +1,7 @@
 # ECS EC2 Windows (Metrics)
 
 
-This template section provides an example template for deployin the Open Telemetry collector as a sidecar for collecting Metrics on ECS EC2 Windows. This template is not meant to be used in production as is, it is intended as a demonstration/example.
+This template section provides an example template for deploying the Open Telemetry collector as a sidecar for collecting Metrics on ECS EC2 Windows. This template is not meant to be used in production as is, it is intended as a demonstration/example.
 
 
 
@@ -21,6 +21,11 @@ This template section provides an example template for deployin the Open Telemet
 | ApplicationName | You application name                                                                                                                                                                                                                 |                                                                              | :heavy_check_mark: |
 | SubsystemName   | You Subsystem name                                                                                                                                                                                                                   | AWS Account ID                                                               | :heavy_check_mark: |
 | PrivateKey      | Your Coralogix Private Key                                                                                                                                                                                                           |                                                                              | :heavy_check_mark: |
+| HealthCheckEnabled     | Enable ECS container health check for the OTEL agent container. | false | |
+| HealthCheckInterval    | Health check interval (seconds)             | 30      |          |
+| HealthCheckTimeout     | Health check timeout (seconds)              | 5       |          |
+| HealthCheckRetries     | Health check retries                        | 3       |          |
+| HealthCheckStartPeriod | Health check start period (seconds)         | 10      |          |
 
 
 
@@ -41,6 +46,35 @@ For Windows, this receiver does not support being run as a daemonset, as such, e
 ### Open Telemetry Configuration
 
 The Open Telemetry configuration is embedded in this CloudFormation template by default. However, you have the option of specifying your own configuration by modifying the template. The Coralogix Open Telemetry distribution supports reading configuration over HTTP as well as an Environment Variable. Note that Environment Variables must be raw strings. Base64 encoding is not supported.
+
+### ECS Container Health Check
+
+You can enable and customize the ECS container health check for the OTEL agent container using the following parameters:
+- `HealthCheckEnabled` (default: false)
+- `HealthCheckInterval` (default: 30)
+- `HealthCheckTimeout` (default: 5)
+- `HealthCheckRetries` (default: 3)
+- `HealthCheckStartPeriod` (default: 10)
+
+Example deployment with custom health check settings:
+
+```sh
+aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
+    --region <region> \
+    --parameter-overrides \
+        ClusterName=<ecs cluster name> \
+        AppImage=<your-app-image> \
+        OtelImage=<otel-image> \
+        PrivateKey=<your-private-key> \
+        ApplicationName=<application name> \
+        SubsystemName=<subsystem name> \
+        CoralogixRegion=<coralogix-region> \
+        HealthCheckEnabled=true \
+        HealthCheckInterval=60 \
+        HealthCheckTimeout=10 \
+        HealthCheckRetries=5 \
+        HealthCheckStartPeriod=20
+```
 
 ### Image
 

--- a/opentelemetry/ecs-ec2-windows/template.yaml
+++ b/opentelemetry/ecs-ec2-windows/template.yaml
@@ -29,6 +29,34 @@ Parameters:
         - Singapore
         - US
 
+  HealthCheckEnabled:
+    Type: String
+    Description: Enable ECS container health check for the OTEL agent container.
+    AllowedValues: ["true", "false"]
+    Default: "false"
+
+  HealthCheckInterval:
+    Type: Number
+    Description: Health check interval (seconds). Only used if HealthCheckEnabled is true
+    Default: "30"
+
+  HealthCheckTimeout:
+    Type: Number
+    Description: Health check timeout (seconds). Only used if HealthCheckEnabled is true
+    Default: "5"
+
+  HealthCheckRetries:
+    Type: Number
+    Description: Health check retries. Only used if HealthCheckEnabled is true
+    Default: "3"
+
+  HealthCheckStartPeriod:
+    Type: Number
+    Description: Health check start period (seconds). Only used if HealthCheckEnabled is true
+    Default: "10"
+
+Conditions:
+  EnableHealthCheck: !Equals [!Ref HealthCheckEnabled, "true"]
 
 Mappings:
   CoralogixRegionMap:
@@ -209,6 +237,15 @@ Resources:
                       exporters:
                         - coralogix
 
+          HealthCheck: !If
+            - EnableHealthCheck
+            - Command:
+                - "/healthcheck"
+              Interval: !Ref HealthCheckInterval
+              Timeout: !Ref HealthCheckTimeout
+              Retries: !Ref HealthCheckRetries
+              StartPeriod: !Ref HealthCheckStartPeriod
+            - !Ref AWS::NoValue
 
         ### --- your app task definition goes here --- ###
         - Name: "win-app"

--- a/opentelemetry/ecs-ec2-windows/template.yaml
+++ b/opentelemetry/ecs-ec2-windows/template.yaml
@@ -53,7 +53,7 @@ Parameters:
   HealthCheckStartPeriod:
     Type: Number
     Description: Health check start period (seconds). Only used if HealthCheckEnabled is true
-    Default: "10"
+    Default: "60"
 
 Conditions:
   EnableHealthCheck: !Equals [!Ref HealthCheckEnabled, "true"]

--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,9 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 1.0.3 / 2025-05-20
+- Added healthcheck to ECS task.
+
 ### 1.0.2 / 2025-03-25
 - Add Head Sampling to traces of the ECS-EC2 integartion to reduce the initial data ingestion, provided parameters to disable and customize.
 

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -62,6 +62,11 @@ The sampling configuration can be adjusted using the following parameters:
 | EnableHeadSampler       |       Enable or disable head sampling for traces. When enabled, sampling decisions are made at the collection point before any processing occurs.            | true 
 | SamplerMode       |       The sampling mode to use:<br>**proportional**: Maintains the relative proportion of traces across services.<br>**equalizing**: Attempts to sample equal numbers of traces from each service.<br>**hash_seed**: Uses consistent hashing to ensure the same traces are sampled across restarts.            | proportional 
 | SamplingPercentage       |        The percentage of traces to sample (0-100). A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.            | 10 
+| HealthCheckEnabled     | Enable ECS container health check for the OTEL agent container. | false | |
+| HealthCheckInterval    | Health check interval (seconds)             | 30      |          |
+| HealthCheckTimeout     | Health check timeout (seconds)              | 5       |          |
+| HealthCheckRetries     | Health check retries                        | 3       |          |
+| HealthCheckStartPeriod | Health check start period (seconds)         | 10      |          |
 ## Deploy the Cloudformation template:
 
 ```sh
@@ -72,7 +77,8 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
         ClusterName=<ecs cluster name> \
         CDOTImageVersion=<image tag> \
         CoralogixApiKey=<your-private-key> \
-        CoralogixRegion=<coralogix-region>
+        CoralogixRegion=<coralogix-region> \
+        HealthCheckEnabled=true
 ```
 
 **When using a custom configuration for OpenTelemetry**
@@ -87,7 +93,8 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
         CoralogixApiKey=<your-private-key> \
         CoralogixRegion=<coralogix-region> \
         CustomConfig=<Parameter Store Name> \
-        TaskExecutionRoleARN=<task-execution-role-arn>
+        TaskExecutionRoleARN=<task-execution-role-arn> \
+        HealthCheckEnabled=true
 ```
 
 Note that these are just examples of how this could be deployed. You can also deploy this template using the AWS Console or any Cloudformation management tools.
@@ -112,6 +119,32 @@ The healthy response should look like this:
   "upSince": "2023-10-25T15:37:32.003837622Z",
   "uptime": "2m5.2610063s"
 }
+```
+
+### ECS Container Health Check
+
+You can customize the health check settings using the following parameters:
+- `HealthCheckInterval` (default: 30)
+- `HealthCheckTimeout` (default: 5)
+- `HealthCheckRetries` (default: 3)
+- `HealthCheckStartPeriod` (default: 10)
+
+Example deployment with custom health check settings:
+
+```sh
+aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
+    --region <region> \
+    --parameter-overrides \
+        DefaultApplicationName=<application name> \
+        ClusterName=<ecs cluster name> \
+        CDOTImageVersion=<image tag> \
+        CoralogixApiKey=<your-private-key> \
+        CoralogixRegion=<coralogix-region> \
+        HealthCheckEnabled=true \
+        HealthCheckInterval=60 \
+        HealthCheckTimeout=10 \
+        HealthCheckRetries=5 \
+        HealthCheckStartPeriod=20
 ```
 
 ### Further info

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -106,6 +106,32 @@ Parameters:
       Default is 10% sampling.
     Default: "10"
 
+  HealthCheckEnabled:
+    Type: String
+    Description: Enable ECS container health check for the OTEL agent container.
+    AllowedValues: ["true", "false"]
+    Default: "false"
+
+  HealthCheckInterval:
+    Type: Number
+    Description: Health check interval (seconds). Only used if HealthCheckEnabled is true
+    Default: "30"
+
+  HealthCheckTimeout:
+    Type: Number
+    Description: Health check timeout (seconds). Only used if HealthCheckEnabled is true
+    Default: "5"
+
+  HealthCheckRetries:
+    Type: Number
+    Description: Health check retries. Only used if HealthCheckEnabled is true
+    Default: "3"
+
+  HealthCheckStartPeriod:
+    Type: Number
+    Description: Health check start period (seconds). Only used if HealthCheckEnabled is true
+    Default: "10"
+
 Conditions:
   UseImage: !Not [!Equals [ !Ref Image, "none" ]]
   UseDefaultConfig: !Equals [ !Ref CustomConfig, "none" ]
@@ -116,6 +142,7 @@ Conditions:
     Fn::Equals:
       - !Ref EnableHeadSampler
       - "false"
+  EnableHealthCheck: !Equals [!Ref HealthCheckEnabled, "true"]
 
 Rules:
   ValidateTaskExecutionRole:
@@ -504,6 +531,15 @@ Resources:
             - !Sub "coralogixrepo/coralogix-otel-collector:${CDOTImageVersion}"
 
           Essential: true
+          HealthCheck: !If
+            - EnableHealthCheck
+            - Command:
+                - "/healthcheck"
+              Interval: !Ref HealthCheckInterval
+              Timeout: !Ref HealthCheckTimeout
+              Retries: !Ref HealthCheckRetries
+              StartPeriod: !Ref HealthCheckStartPeriod
+            - !Ref AWS::NoValue
 
           PortMappings:
             # otel grpc endpoint
@@ -604,6 +640,16 @@ Resources:
             - !Sub "coralogixrepo/coralogix-otel-collector:${CDOTImageVersion}"
             
           Essential: true
+          HealthCheck: !If
+            - EnableHealthCheck
+            - Command:
+                - "/healthcheck"
+              Interval: !Ref HealthCheckInterval
+              Timeout: !Ref HealthCheckTimeout
+              Retries: !Ref HealthCheckRetries
+              StartPeriod: !Ref HealthCheckStartPeriod
+            - !Ref AWS::NoValue
+
           PortMappings:
             # otel grpc endpoint
             - HostPort: 4317


### PR DESCRIPTION
# Description

Added healthcheck parameter and its properties to the template.

The healthcheck is using a binary added to coralogix otel that can be called by the ECS task.

[CDS-2147](https://coralogix.atlassian.net/browse/CDS-2147)

# Checklist:
- I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

[CDS-2147]: https://coralogix.atlassian.net/browse/CDS-2147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ