### PR TITLE
Add support for s3 provider to read otel configuration file

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,7 +5,12 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
-### 1.0.5 / 2025-01-27
+### 1.0.6 / 2025-07-28
+- Added support for s3 provider to read otel config.
+- TaskRoleARN is created by the template for Parameter Store and S3.
+- Added examples folder with complate example config file.
+
+### 1.0.5 / 2025-07-16
 - Added spanmetrics pipline (enebaled by default) and traces/db, each have its own parameter.
 
 ### 1.0.4 / 2025-06-02

--- a/opentelemetry/ecs-ec2/README.md
+++ b/opentelemetry/ecs-ec2/README.md
@@ -58,26 +58,32 @@ When enabled, database operation traces are processed separately with dedicated 
 
 | Parameter        | Description                                                                                                                                                                                                                          | Default Value                                                            | Required           |
 |------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|--------------------|
+| ConfigSource     | Select the configuration source for OpenTelemetry Collector:<br>- `template`: Use built-in template configuration<br>- `s3`: Use configuration file from S3 (via S3 URI)<br>- `ssm`: Use configuration from SSM Parameter Store | template                                                                |                    |
 | ClusterName      | The name of an **existing** ECS Cluster                                                                                                                                                                                              |                                                                          | :heavy_check_mark: |
 | CDOTImageVersion | The Coralogix OpenTelemetry Collector Image version/tag to use. See available tags [here](https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags)                                                                     |                                                                          |                    |
-| Memory           | The amount of memory to allocate to the OpenTelemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 256                                                                      |                    |
+| Image            | The OpenTelemetry Collector Image to use. If specified, this value will override the CDOTImageVersion parameter and the coralogix otel collector image.                                                                              | none                                                                     |                    |
+| Memory           | The amount of memory to allocate to the OpenTelemetry container.<br>*Assigning too much memory can lead to the ECS Service not being deployed. Make sure that values are within the range of what is available on your ECS Cluster* | 2048                                                                     |                    |
 | CoralogixRegion  | The region of your Coralogix Account                                                                                                                                                                                                 | *Allowed Values:* <br>- EU1<br>- EU2<br>- AP1<br>- AP2<br>- AP3<br>- US1<br>- US2 | :heavy_check_mark: |
-| ApplicationName  | Your application name                                                                                                                                                                                                                 |                                                                          | :heavy_check_mark: |
-| SubsystemName    | Your Subsystem name |                                                            | :heavy_check_mark: |
+| DefaultApplicationName | Your application name                                                                                                                                                                                                                 | OTEL                                                                     |                    |
+| DefaultSubsystemName | Your Subsystem name                                                                                                                                                                                                                 | ECS-EC2                                                                  |                    |
 | CoralogixApiKey  | The Send-Your-Data API key for your Coralogix account. See: https://coralogix.com/docs/send-your-data-api-key/                                                                                                                       |                                                                          | :heavy_check_mark: |
-| CustomConfig       | The name of a Parameter Store to use as a custom configuration. Must be in the same region as your ECS cluster.            | none                                                                         |                    |
-| TaskExecutionRoleARN       |       When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.            | Default                                                                        |                    |
-| EnableHeadSampler       |       Enable or disable head sampling for traces. When enabled, sampling decisions are made at the collection point before any processing occurs.            | true 
-| EnableSpanMetrics       |       Enable or disable the spanmetrics connector and pipeline. When enabled (default), span metrics will be generated from traces.            | true 
-| EnableTracesDB       |       Enable or disable the traces/db pipeline for database operation metrics. When enabled, database operation metrics will be generated. Note: This feature requires spanmetrics to be enabled.            | false 
-| SamplerMode       |       The sampling mode to use:<br>**proportional**: Maintains the relative proportion of traces across services.<br>**equalizing**: Attempts to sample equal numbers of traces from each service.<br>**hash_seed**: Uses consistent hashing to ensure the same traces are sampled across restarts.            | proportional 
-| SamplingPercentage       |        The percentage of traces to sample (0-100). A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.            | 10 
-| HealthCheckEnabled     | Enable ECS container health check for the OTEL agent container. Requires OTEL collector image version v0.4.2 or later.| false | |
-| HealthCheckInterval    | Health check interval (seconds)             | 30      |          |
-| HealthCheckTimeout     | Health check timeout (seconds)              | 5       |          |
-| HealthCheckRetries     | Health check retries                        | 3       |          |
-| HealthCheckStartPeriod | Health check start period (seconds)         | 10      |          |
+| S3ConfigBucket   | S3 bucket name containing the configuration file. Required when ConfigSource is 's3'.                                                                                                                                                |                                                                          |                    |
+| S3ConfigKey      | S3 object key (file path) for the configuration file. Required when ConfigSource is 's3'.                                                                                                                                           |                                                                          |                    |
+| CustomConfig     | The name of a Parameter Store to use as a custom configuration. Required when ConfigSource is 'ssm'.                                                                                                                                | none                                                                     |                    |
+| EnableHeadSampler | Enable or disable head sampling for traces. When enabled, sampling decisions are made at the collection point before any processing occurs.                                                                                        | true                                                                     |                    |
+| EnableSpanMetrics | Enable or disable the spanmetrics connector and pipeline. When enabled (default), span metrics will be generated from traces.                                                                                                      | true                                                                     |                    |
+| EnableTracesDB   | Enable or disable the traces/db pipeline for database operation metrics. When enabled, database operation metrics will be generated. Note: This feature requires spanmetrics to be enabled.                                           | false                                                                    |                    |
+| SamplerMode      | The sampling mode to use:<br>**proportional**: Maintains the relative proportion of traces across services.<br>**equalizing**: Attempts to sample equal numbers of traces from each service.<br>**hash_seed**: Uses consistent hashing to ensure the same traces are sampled across restarts. | proportional                                                             |                    |
+| SamplingPercentage | The percentage of traces to sample (0-100). A value of 100 means all traces will be sampled, while 0 means no traces will be sampled.                                                                                            | 10                                                                       |                    |
+| HealthCheckEnabled | Enable ECS container health check for the OTEL agent container. Requires OTEL collector image version v0.4.2 or later.                                                                                                            | false                                                                    |                    |
+| HealthCheckInterval | Health check interval (seconds)                                                                                                                                                                                                     | 30                                                                       |                    |
+| HealthCheckTimeout | Health check timeout (seconds)                                                                                                                                                                                                      | 5                                                                        |                    |
+| HealthCheckRetries | Health check retries                                                                                                                                                                                                               | 3                                                                        |                    |
+| HealthCheckStartPeriod | Health check start period (seconds)                                                                                                                                                                                               | 10                                                                       |                    |
+
 ## Deploy the Cloudformation template:
+
+### Default Template Configuration
 
 ```sh
 aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
@@ -91,19 +97,38 @@ aws cloudformation deploy --template-file template.yaml --stack-name <stack_name
         HealthCheckEnabled=true
 ```
 
-**When using a custom configuration for OpenTelemetry**
+### S3 Configuration
+
+For large configurations that exceed SSM Parameter Store limits, you can store your configuration in S3:
 
 ```sh
 aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
     --region <region> \
     --parameter-overrides \
-        DefaultApplicationName=<application name> \
+        ConfigSource=s3 \
+        S3ConfigBucket=<your-s3-bucket> \
+        S3ConfigKey=<path/to/config.yaml> \
         ClusterName=<ecs cluster name> \
         CDOTImageVersion=<image tag> \
         CoralogixApiKey=<your-private-key> \
         CoralogixRegion=<coralogix-region> \
+        HealthCheckEnabled=true
+```
+
+### SSM Parameter Store Configuration
+
+For custom configurations stored in SSM Parameter Store:
+
+```sh
+aws cloudformation deploy --template-file template.yaml --stack-name <stack_name> \
+    --region <region> \
+    --parameter-overrides \
+        ConfigSource=ssm \
         CustomConfig=<Parameter Store Name> \
-        TaskExecutionRoleARN=<task-execution-role-arn> \
+        ClusterName=<ecs cluster name> \
+        CDOTImageVersion=<image tag> \
+        CoralogixApiKey=<your-private-key> \
+        CoralogixRegion=<coralogix-region> \
         HealthCheckEnabled=true
 ```
 
@@ -111,11 +136,52 @@ Note that these are just examples of how this could be deployed. You can also de
 
 ### OpenTelemetry Configuration
 
-An OpenTelemetry configuration is embedded in the cloudformation template by default, however, you do have the option of specifying your own configuration, stored in a Parameter Store, using the `CustomConfig` parameter. When using a custom configuration, you must ensure your EC2 host has access to the AWS Systems Manager API and the OTEL containers have read permission for the specified Parameter Store. You will need to create a task execution role with those permissions and align it using the `TaskExecutionRoleARN` parameter.
+The template supports three configuration sources:
+
+1. **Template Configuration (Default)**: An OpenTelemetry configuration is embedded in the cloudformation template by default.
+
+2. **S3 Configuration**: For large configurations that exceed SSM Parameter Store limits, you can store your configuration file in S3. The template will automatically create the necessary IAM roles for S3 access.
+
+3. **SSM Parameter Store**: You can specify your own configuration stored in AWS Systems Manager Parameter Store using the `CustomConfig` parameter. When using SSM configuration, you must ensure your EC2 host has access to the AWS Systems Manager API and the OTEL containers have read permission for the specified Parameter Store.
 
 The default configuration will monitor container logs, listen for logs, metrics and traces on port `4317/4318`, and monitor container metrics using the `awsecscontainermetricsd` receiver. The `awsecscontainermetricsd` receiver is based on the [awsecscontainermetrics](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/awsecscontainermetricsreceiver) receiver, however, instead of monitoring a single task, metrics will be collected from all containers. If you do not wish to collect container metrics, comment out or delete the metrics/container-metrics pipeline from the configuration.
 
 The embeded default OpenTelemetry configuration can be viewed [here](./template.yaml#L90).
+
+### Using Complete Example Configuration with S3
+
+For customers who need to customize their OpenTelemetry configuration beyond the template defaults, you can use the complete example configuration from the `examples` folder as a starting point for S3 deployment.
+
+#### Example Configuration File
+
+A comprehensive example configuration is provided in [`examples/comprehensive-config.yaml`](./examples/comprehensive-config.yaml) that includes:
+
+- **Receivers**: OTLP (gRPC/HTTP), AWS ECS Container Metrics, Prometheus, File Log, Host Metrics
+- **Processors**: ECS Attributes, Transform, Filter, Batch, Resource Detection, Probabilistic Sampler
+- **Exporters**: Coralogix (logs, metrics, traces), Coralogix Resource Catalog
+- **Connectors**: Forward, Span Metrics, Database Span Metrics
+- **Pipelines**: Multiple pipeline configurations for different sampling and metrics scenarios
+- **Telemetry**: Proper metrics configuration with Prometheus endpoint
+
+#### Configuration Scenarios
+
+The example configuration demonstrates different deployment scenarios:
+
+1. **ALL ENABLED** (EnableSpanMetrics=true, EnableTracesDB=true, EnableSampling=true) - *Currently active*
+2. **ALL DISABLED** (EnableSpanMetrics=false, EnableTracesDB=false, EnableSampling=false)
+3. **SPAN METRICS ONLY** (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=true)
+4. **SPAN METRICS NO SAMPLING** (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=false)
+
+#### Steps to Use with S3:
+
+1. **Download the Example**: Copy the configuration from [`examples/comprehensive-config.yaml`](./examples/comprehensive-config.yaml)
+2. **Modify as Needed**: 
+   - Choose the appropriate scenario by uncommenting/commenting the relevant pipeline sections
+   - Add your custom receivers, processors, or exporters
+3. **Upload to S3**: Save the modified configuration as a YAML file and upload to your S3 bucket
+4. **Deploy with S3**: Use the S3 deployment method with your custom configuration
+
+This approach allows you to leverage the full power of OpenTelemetry while maintaining the convenience of CloudFormation deployment.
 
 ### Health Check
 

--- a/opentelemetry/ecs-ec2/examples/comprehensive-config.yaml
+++ b/opentelemetry/ecs-ec2/examples/comprehensive-config.yaml
@@ -1,0 +1,441 @@
+# Comprehensive OpenTelemetry Configuration for Coralogix ECS EC2 Integration
+# 
+# This configuration shows the different deployment scenarios available in the CloudFormation template.
+# Choose the scenario that matches your deployment parameters:
+# Current configuratiion is for scenario 1 (ALL ENABLED)
+# 1. ALL ENABLED (EnableSpanMetrics=true, EnableTracesDB=true, EnableSampling=true)
+# 2. ALL DISABLED (EnableSpanMetrics=false, EnableTracesDB=false, EnableSampling=false) 
+# 3. SPAN METRICS ONLY (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=true)
+# 4. SPAN METRICS NO SAMPLING (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=false)
+#
+# Environment Variables Used:
+# - ${CORALOGIX_DOMAIN}: Your Coralogix domain
+# - ${PRIVATE_KEY}: Your Coralogix API key  
+# - ${APP_NAME}: Application name
+# - ${SUB_SYS}: Subsystem name
+# - ${SAMPLING_PERCENTAGE}: Sampling percentage (0-100)
+# - ${SAMPLER_MODE}: Sampling mode (proportional, equalizing, hash_seed)
+
+receivers:
+
+  otlp:
+    protocols:
+      grpc: { endpoint: 0.0.0.0:4317, max_recv_msg_size_mib: 20 }
+      http: { endpoint: 0.0.0.0:4318 }
+
+  # ECS Container Metrics (enabled by default)
+  awsecscontainermetricsd:
+
+  # Prometheus metrics for the collector itself (enabled by default)
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: otel-collector-metrics
+        scrape_interval: 30s
+        static_configs:
+        - targets: ["localhost:8888"]
+
+  # Container logs from Docker (enabled by default)
+  filelog:
+    start_at: end
+    force_flush_period: 0
+    include:
+      - /hostfs/var/lib/docker/containers/*/*.log
+    include_file_name: false
+    include_file_path: true
+    operators:
+      - type: router
+        id: docker_log_json_parser
+        routes:
+          - output: json_parser
+            expr: 'body matches "^\\{\"log\".*\\}"'
+        default: move_log_file_path
+
+      - type: json_parser
+        parse_from: body
+        parse_to: body
+        output: recombine
+        timestamp:
+          parse_from: body.time
+          layout: '%Y-%m-%dT%H:%M:%S.%fZ'
+
+      - type: recombine
+        id: recombine
+        output: move_log_file_path
+        combine_field: body.log
+        source_identifier: attributes["log.file.path"]
+        is_last_entry: body.log endsWith "\n"
+        force_flush_period: 10s	
+        on_error: send
+        combine_with: ""
+
+      - type: move
+        id: move_log_file_path
+        from: attributes["log.file.path"]
+        to: resource["log.file.path"]
+
+  # Host metrics (CPU, memory, filesystem, etc.) - enabled by default
+  hostmetrics:
+    root_path: /
+    collection_interval: 10s
+    scrapers:
+      cpu: { metrics: { system.cpu.utilization: { enabled: true } } }
+      filesystem:
+        exclude_fs_types: { fs_types: [autofs, binfmt_misc, bpf, cgroup2, configfs, debugfs, devpts, devtmpfs, fusectl, hugetlbfs, iso9660, mqueue, nsfs, overlay, proc, procfs, pstore, rpc_pipefs, securityfs, selinuxfs, squashfs, sysfs, tracefs], match_type: strict }
+        exclude_mount_points: { match_type: regexp, mount_points: [/dev/*, /proc/*, /sys/*, /run/k3s/containerd/*, /run/containerd/runc/*, /var/lib/docker/*, /var/lib/kubelet/*, /snap/*] }
+      memory: { metrics: { system.memory.utilization: { enabled: true } } }
+      process:
+        metrics:
+          process.cpu.utilization: { enabled: true }
+          process.memory.utilization: { enabled: true }
+          process.threads: { enabled: true }
+        mute_process_exe_error: true
+        mute_process_user_error: true
+
+processors:
+  # ECS attributes for container logs (enabled by default)
+  ecsattributes/container-logs:
+    container_id:
+      sources:
+        - "log.file.path"
+
+  # Transform logs (enabled by default)
+  transform/logs:
+    error_mode: ignore
+    log_statements:
+      - context: resource
+        statements:
+          - set(attributes["cx_container_id"], attributes["docker.id"])
+          - set(attributes["aws_ecs_task_family"], attributes["aws.ecs.task.definition.family"])
+          - set(attributes["image_id"], attributes["image.id"])
+          - delete_key(attributes, "image.id")
+
+  # Entity event processing (enabled by default)
+  transform/entity-event:
+    error_mode: silent
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["otel.entity.id"]["host.id"], resource.attributes["host.id"])
+          - merge_maps(attributes, resource.attributes, "insert")
+      - context: resource
+        statements:
+          - keep_keys(attributes, [""])
+
+  # Prometheus metrics cleanup (enabled by default)
+  transform/prometheus:
+    error_mode: ignore
+    metric_statements:
+      - context: metric
+        statements:
+          - replace_pattern(name, "_total$", "")
+      - context: datapoint
+        statements:
+          - delete_key(attributes, "otel_scope_name") where resource.attributes["service.name"] == "cdot"
+          - delete_key(attributes, "service.name") where resource.attributes["service.name"] == "cdot"
+      - context: resource
+        statements:
+          - delete_key(attributes, "service.instance.id") where attributes["service.name"] == "cdot"
+          - delete_key(attributes, "service.name") where attributes["service.name"] == "cdot"
+
+  # Semantic conventions for HTTP methods (enabled by default)
+  transform/semconv:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["http.method"], attributes["http.request.method"]) where attributes["http.request.method"] != nil
+
+  # Transform statements for database namespace fixes (OPTIONAL - customize as needed)
+  # Customize the statements below for your database spans
+  transform/spanmetrics:
+    error_mode: silent
+    trace_statements:
+      - context: span
+        statements:
+        - set(attributes["db.namespace"], attributes["db.name"]) where attributes["db.namespace"] == nil
+        - set(attributes["db.namespace"], attributes["server.address"]) where attributes["db.namespace"] == nil
+        - set(attributes["db.namespace"], attributes["network.peer.name"]) where attributes["db.namespace"] == nil
+        - set(attributes["db.namespace"], attributes["net.peer.name"]) where attributes["db.namespace"] == nil
+        - set(attributes["db.namespace"], attributes["db.system"]) where attributes["db.namespace"] == nil
+        - set(attributes["db.operation.name"], attributes["db.operation"]) where attributes["db.operation.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.sql.table"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.cassandra.table"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.mongodb.collection"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.redis.database_index"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.elasticsearch.path_parts.index"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["db.cosmosdb.container"]) where attributes["db.collection.name"] == nil
+        - set(attributes["db.collection.name"], attributes["aws_dynamodb.table_names"]) where attributes["db.collection.name"] == nil
+    #   
+    #     - replace_pattern(attributes["db.query.text"], "\\d+", "?") # removes potential IDs for the attribute
+    #     - set(attributes["span.duration_ns"], span.end_time_unix_nano - span.start_time_unix_nano) # stores the span duration in ns in an attribute
+
+  # Filter for database spans (enabled when using database processing)
+  filter/db_spanmetrics:
+    traces:
+      span:
+        - 'attributes["db.system"] == nil'
+
+  # Basic processing (enabled by default)
+  batch: { send_batch_max_size: 2048, send_batch_size: 1024, timeout: 1s }
+
+  # Resource metadata (enabled by default)
+  resource/metadata:
+    attributes:
+      - action: upsert
+        key: cx.otel_integration.name
+        value: coralogix-integration-ecs-ec2
+
+  # Resource detection for collector metrics (enabled by default)
+  resourcedetection/otel-collector:
+    detectors: [system, env, ecs, ec2]
+    override: false
+    timeout: 2s
+    system:
+      resource_attributes:
+        host.id: { enabled: false }
+        host.cpu.cache.l2.size: { enabled: true }
+        host.cpu.stepping: { enabled: true }
+        host.cpu.model.name: { enabled: true }
+        host.cpu.model.id: { enabled: true }
+        host.cpu.family: { enabled: true }
+        host.cpu.vendor.id: { enabled: true }
+        host.mac: { enabled: true }
+        host.ip: { enabled: true }
+        os.description: { enabled: true }
+
+  # Resource detection for entity events (enabled by default)
+  resourcedetection/entity:
+    detectors: [system, env, ecs, ec2]
+    override: false
+    timeout: 2s
+    system:
+      resource_attributes:
+        host.id: { enabled: false }
+        host.cpu.cache.l2.size: { enabled: true }
+        host.cpu.stepping: { enabled: true }
+        host.cpu.model.name: { enabled: true }
+        host.cpu.model.id: { enabled: true }
+        host.cpu.family: { enabled: true }
+        host.cpu.vendor.id: { enabled: true }
+        host.mac: { enabled: true }
+        host.ip: { enabled: true }
+        os.description: { enabled: true }
+
+  # Probabilistic sampling (enabled when EnableSampling=true)
+  probabilistic_sampler:
+    sampling_percentage: 10
+    mode: proportional
+
+exporters:
+  # Coralogix exporter for traces, metrics, and logs (enabled by default)
+  coralogix:
+    domain: "${CORALOGIX_DOMAIN}"
+    private_key: "${PRIVATE_KEY}"
+    application_name: "${APP_NAME}"
+    subsystem_name: "${SUB_SYS}"
+    application_name_attributes:
+    - "aws.ecs.cluster"
+    - "aws.ecs.task.definition.family"
+    subsystem_name_attributes:
+    - "aws.ecs.container.name"
+    - "aws.ecs.docker.name"
+    - "docker.name"
+    timeout: 30s
+
+  # Resource catalog exporter (enabled by default)
+  coralogix/resource_catalog:
+    application_name: resource
+    domain: ${CORALOGIX_DOMAIN}
+    private_key: ${PRIVATE_KEY}
+    logs:
+      headers:
+        X-Coralogix-Distribution: ecs-ec2-integration/1.0.0
+        x-coralogix-ingress: metadata-as-otlp-logs/v1
+    subsystem_name: catalog
+    timeout: 30s
+
+connectors:
+  # Forward connectors for sampling and database processing
+  forward/sampled: {}
+  forward/db: {}
+
+  # Span metrics connector (enabled when EnableSpanMetrics=true)
+  spanmetrics:
+    dimensions:
+      - name: http.method
+      - name: cgx.transaction
+      - name: cgx.transaction.root
+      - name: status_code
+      - name: db.namespace
+      - name: db.operation.name
+      - name: db.collection.name
+      - name: db.system
+      - name: http.response.status_code
+      - name: rpc.grpc.status_code
+      - name: service.version
+    histogram:
+      explicit:
+        buckets:
+          - 1ms
+          - 4ms
+          - 10ms
+          - 20ms
+          - 50ms
+          - 100ms
+          - 200ms
+          - 500ms
+          - 1s
+          - 2s
+          - 5s
+    metrics_expiration: 5m
+    metrics_flush_interval: '30s'
+    namespace: ""
+
+  # Database-specific span metrics (enabled when EnableTracesDB=true)
+  spanmetrics/db:
+    dimensions:
+      - name: db.namespace
+      - name: db.operation.name
+      - name: db.collection.name
+      - name: db.system
+      - name: service.version
+    histogram:
+      explicit:
+        buckets:
+          - 100us
+          - 1ms
+          - 2ms
+          - 2.5ms
+          - 4ms
+          - 6ms
+          - 10ms
+          - 100ms
+          - 250ms
+    metrics_expiration: 5m
+    metrics_flush_interval: '30s'
+    namespace: db
+
+extensions:
+  # Health check extension (enabled by default)
+  health_check: {}
+  # Pprof extension for debugging (enabled by default)
+  pprof: {}
+
+service:
+  # Extensions (enabled by default)
+  extensions:
+    - health_check
+    - pprof
+
+  # Pipeline configurations - DIFFERENT SCENARIOS:
+  pipelines:
+    # Container logs pipeline (enabled by default)
+    logs/container-logs:
+      receivers: [filelog]
+      processors: [ecsattributes/container-logs, resource/metadata, transform/logs, batch]
+      exporters: [coralogix]
+
+    # Container metrics pipeline (enabled by default)
+    metrics/container-metrics:
+      receivers: [awsecscontainermetricsd]
+      processors: [batch]
+      exporters: [coralogix]
+
+    # OTLP logs pipeline (enabled by default)
+    logs/otlp:
+      receivers: [otlp]
+      processors: [resource/metadata, batch]
+      exporters: [coralogix]
+
+    # OTLP metrics pipeline (enabled by default)
+    metrics/otlp:
+      receivers: [otlp]
+      processors: [resource/metadata, batch]
+      exporters: [coralogix]
+
+    # ===== TRACES PIPELINE CONFIGURATIONS =====
+    # 
+    # SCENARIO 1: ALL ENABLED (EnableSpanMetrics=true, EnableTracesDB=true, EnableSampling=true)
+    traces:
+      receivers: [otlp]
+      processors: [resource/metadata, transform/semconv, batch]
+      exporters: [forward/sampled, spanmetrics, forward/db]
+    
+    traces/sampled:
+      receivers: [forward/sampled]
+      processors: [probabilistic_sampler, batch]
+      exporters: [coralogix]
+    
+    traces/db:
+      receivers: [forward/db]
+      processors: [filter/db_spanmetrics, batch]
+      exporters: [spanmetrics/db]
+    
+    metrics/spanmetrics:
+      receivers: [spanmetrics]
+      processors: [batch]
+      exporters: [coralogix]
+    
+    metrics/spanmetrics-db:
+      receivers: [spanmetrics/db]
+      processors: [batch]
+      exporters: [coralogix]
+    
+    # SCENARIO 2: ALL DISABLED (EnableSpanMetrics=false, EnableTracesDB=false, EnableSampling=false)
+    # traces/otlp:
+    #   receivers: [otlp]
+    #   processors: [resource/metadata, transform/semconv, batch]
+    #   exporters: [coralogix]
+    #
+    # SCENARIO 3: SPAN METRICS ONLY (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=true)
+    # traces/otlp:
+    #   receivers: [otlp]
+    #   processors: [resource/metadata, transform/semconv, batch]
+    #   exporters: [forward/sampled, spanmetrics]
+    # 
+    # traces/sampled:
+    #   receivers: [forward/sampled]
+    #   processors: [probabilistic_sampler, batch]
+    #   exporters: [coralogix]
+    # 
+    # metrics/spanmetrics:
+    #   receivers: [spanmetrics]
+    #   processors: [batch]
+    #   exporters: [coralogix]
+    #
+    # SCENARIO 4: SPAN METRICS NO SAMPLING (EnableSpanMetrics=true, EnableTracesDB=false, EnableSampling=false)
+    # traces:
+    #   receivers: [otlp]
+    #   processors: [resource/metadata, transform/semconv, batch]
+    #   exporters: [coralogix, spanmetrics]
+    # 
+    # metrics/spanmetrics:
+    #   receivers: [spanmetrics]
+    #   processors: [batch]
+    #   exporters: [coralogix]
+
+    # Resource catalog pipeline (enabled by default)
+    logs/resource_catalog:
+      receivers: [hostmetrics]
+      processors: [resourcedetection/entity, transform/entity-event, batch]
+      exporters: [coralogix/resource_catalog]
+
+    # Collector metrics pipeline (enabled by default)
+    metrics/otel-collector:
+      receivers: [prometheus, hostmetrics]
+      processors: [resourcedetection/otel-collector, resource/metadata, transform/prometheus, batch]
+      exporters: [coralogix]
+
+  # Telemetry configuration (enabled by default)
+  telemetry:
+    logs:
+      encoding: json
+      level: warn
+    metrics:
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888 

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: |
   Create an OTEL ECS Daemon Service on an ECS Cluster.
-  NOTE: Contains conditional IAM roles (only created for s3 and ssm). 
+  NOTE: Contains conditional IAM roles (only created for s3 and Parameter Store). 
   IAM warning appears even when no IAM resources are created - this is expected and safe to acknowledge.
 
 Metadata:
@@ -38,7 +38,7 @@ Metadata:
           - S3ConfigKey
       
       - Label:
-          default: "SSM Configuration (required when ConfigSource=ssm)"
+          default: "Parameter Store Configuration (required when ConfigSource=parameter-store)"
         Parameters:
           - CustomConfig
       
@@ -65,7 +65,7 @@ Metadata:
       S3ConfigKey:
         default: "S3 Object Key (file path)"
       CustomConfig:
-        default: "SSM Parameter Name"
+        default: "Parameter Store Parameter Name"
 
       ClusterName:
         default: "ECS Cluster Name"
@@ -111,9 +111,9 @@ Parameters:
       Select the configuration source for OpenTelemetry Collector.
       - 'template': Use built-in template configuration
       - 's3': Use configuration file from S3 (via S3 URI)
-      - 'ssm': Use configuration from SSM Parameter Store
+      - 'parameter-store': Use configuration from AWS Systems Manager Parameter Store
     Default: "template"
-    AllowedValues: ["template", "s3", "ssm"]
+    AllowedValues: ["template", "s3", "parameter-store"]
 
   S3ConfigBucket:
     Type: String
@@ -198,8 +198,8 @@ Parameters:
   CustomConfig:
     Type: String
     Description: |
-      The name of a Parameter Store to use as a custom configuration.
-      Required when ConfigSource is 'ssm'.
+      The name of an AWS Systems Manager Parameter Store parameter to use as a custom configuration.
+      Required when ConfigSource is 'parameter-store'.
     Default: "none"
 
   EnableHeadSampler:
@@ -278,7 +278,7 @@ Conditions:
   UseImage: !Not [!Equals [!Ref Image, "none"]]
   UseDefaultConfig: !Equals [!Ref ConfigSource, "template"]
   UseS3Config: !Equals [!Ref ConfigSource, "s3"]
-  UseSSMConfig: !Equals [!Ref ConfigSource, "ssm"]
+  UseSSMConfig: !Equals [!Ref ConfigSource, "parameter-store"]
   UseTemplateOrS3Config: !Or [!Equals [!Ref ConfigSource, "template"], !Equals [!Ref ConfigSource, "s3"]]
   DisableHeadSamplerCondition: !Equals [!Ref EnableHeadSampler, "false"]
   EnableSpanMetricsCondition: !Equals [!Ref EnableSpanMetrics, "true"]
@@ -308,19 +308,19 @@ Rules:
                     - ""
         AssertDescription: "S3ConfigBucket and S3ConfigKey must be provided when ConfigSource is 's3'."
 
-  ValidateSSMParameters:
+  ValidateParameterStoreParameters:
     Assertions:
       - Assert:
           Fn::Or:
             - Fn::Not:
                 - Fn::Equals:
                     - !Ref ConfigSource
-                    - "ssm"
+                    - "parameter-store"
             - Fn::Not:
                 - Fn::Equals:
                     - !Ref CustomConfig
                     - "none"
-        AssertDescription: "CustomConfig must be provided when ConfigSource is 'ssm'."
+        AssertDescription: "CustomConfig must be provided when ConfigSource is 'parameter-store'."
 
 
 
@@ -1256,12 +1256,12 @@ Resources:
                   - s3:GetObjectVersion
                 Resource: !Sub "arn:aws:s3:::${S3ConfigBucket}/*"
 
-  # IAM Role for SSM access (only created when ConfigSource=ssm)
+  # IAM Role for Parameter Store access (only created when ConfigSource=parameter-store)
   OtelTaskExecutionRoleSSM:
     Type: AWS::IAM::Role
     Condition: UseSSMConfig
     Properties:
-      RoleName: !Sub "${AWS::StackName}-otel-task-execution-role-ssm"
+      RoleName: !Sub "${AWS::StackName}-otel-task-execution-role-parameter-store"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -1272,7 +1272,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
       Policies:
-        - PolicyName: SSMReadAccess
+        - PolicyName: ParameterStoreReadAccess
           PolicyDocument:
             Version: '2012-10-17'
             Statement:

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -1,8 +1,136 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: |
   Create an OTEL ECS Daemon Service on an ECS Cluster.
+  NOTE: Contains conditional IAM roles (only created for s3 and ssm). 
+  IAM warning appears even when no IAM resources are created - this is expected and safe to acknowledge.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Basic Configuration"
+        Parameters:
+          - ClusterName
+          - CoralogixRegion
+          - CoralogixApiKey
+          - CDOTImageVersion
+      
+      - Label:
+          default: "Configuration Selection"
+        Parameters:
+          - ConfigSource
+      
+      - Label:
+          default: "Default Template Configuration (required when ConfigSource=template)"
+        Parameters:
+          - DefaultApplicationName
+          - DefaultSubsystemName
+          - EnableHeadSampler
+          - EnableSpanMetrics
+          - EnableTracesDB
+          - SamplerMode
+          - SamplingPercentage
+      
+      - Label:
+          default: "S3 Configuration (required when ConfigSource=s3)"
+        Parameters:
+          - S3ConfigBucket
+          - S3ConfigKey
+      
+      - Label:
+          default: "SSM Configuration (required when ConfigSource=ssm)"
+        Parameters:
+          - CustomConfig
+      
+      - Label:
+          default: "Container Configuration"
+        Parameters:
+          - Image
+          - Memory
+      
+      - Label:
+          default: "Health Check Configuration"
+        Parameters:
+          - HealthCheckEnabled
+          - HealthCheckInterval
+          - HealthCheckTimeout
+          - HealthCheckRetries
+          - HealthCheckStartPeriod
+    
+    ParameterLabels:
+      ConfigSource:
+        default: "Select Configuration Source"
+      S3ConfigBucket:
+        default: "S3 Bucket Name"
+      S3ConfigKey:
+        default: "S3 Object Key (file path)"
+      CustomConfig:
+        default: "SSM Parameter Name"
+
+      ClusterName:
+        default: "ECS Cluster Name"
+      CoralogixRegion:
+        default: "Coralogix Region"
+      CoralogixApiKey:
+        default: "Coralogix API Key"
+      DefaultApplicationName:
+        default: "Default Application Name"
+      DefaultSubsystemName:
+        default: "Default Subsystem Name"
+      EnableHeadSampler:
+        default: "Enable Head Sampler"
+      EnableSpanMetrics:
+        default: "Enable Span Metrics"
+      EnableTracesDB:
+        default: "Enable Traces DB"
+      SamplerMode:
+        default: "Sampler Mode"
+      SamplingPercentage:
+        default: "Sampling Percentage"
+      CDOTImageVersion:
+        default: "CDOT Image Version"
+      Image:
+        default: "Custom Image (overrides CDOTImageVersion)"
+      Memory:
+        default: "Memory (MiB)"
+      HealthCheckEnabled:
+        default: "Enable Health Check"
+      HealthCheckInterval:
+        default: "Health Check Interval (seconds)"
+      HealthCheckTimeout:
+        default: "Health Check Timeout (seconds)"
+      HealthCheckRetries:
+        default: "Health Check Retries"
+      HealthCheckStartPeriod:
+        default: "Health Check Start Period (seconds)"
 
 Parameters:
+  ConfigSource:
+    Type: String
+    Description: |
+      Select the configuration source for OpenTelemetry Collector.
+      - 'template': Use built-in template configuration
+      - 's3': Use configuration file from S3 (via S3 URI)
+      - 'ssm': Use configuration from SSM Parameter Store
+    Default: "template"
+    AllowedValues: ["template", "s3", "ssm"]
+
+  S3ConfigBucket:
+    Type: String
+    Description: |
+      S3 bucket name containing the configuration file.
+      Example: 'my-bucket'
+      Required when ConfigSource is 's3'.
+    Default: ""
+
+  S3ConfigKey:
+    Type: String
+    Description: |
+      S3 object key (file path) for the configuration file.
+      Example: 'configs/otel-config.yaml'
+      Required when ConfigSource is 's3'.
+    Default: ""
+
   ClusterName:
     Description: |
       Name of the ECS Cluster onto which to deploy the OTEL Daemon Service.
@@ -12,6 +140,7 @@ Parameters:
     Description: |
       The Coralogix Distribution OpenTelemetry Image Version/Tag.
       View available tags here: https://hub.docker.com/r/coralogixrepo/coralogix-otel-collector/tags
+      This is required when Custom Image is set to "none".
     Type: String
   
   Image:
@@ -19,7 +148,7 @@ Parameters:
       The OpenTelemetry Collector Image to use.
       If specified, this value will override the CDOTImageVersion parameter and
       the coralogix otel collector image.
-    Default: none
+    Default: "none"
     Type: String
 
   Memory:
@@ -70,14 +199,8 @@ Parameters:
     Type: String
     Description: |
       The name of a Parameter Store to use as a custom configuration.
-      If left as 'none' will use the default configuration from the template.
+      Required when ConfigSource is 'ssm'.
     Default: "none"
-
-  TaskExecutionRoleARN:
-    Type: String
-    Description: |
-      When using a Custom Configuration in Parameter Store, set to the ARN of a Task Execution Role that has access to the PS.
-    Default: "Default"
 
   EnableHeadSampler:
     Type: String
@@ -152,42 +275,54 @@ Parameters:
     Default: "10"
 
 Conditions:
-  UseImage: !Not [!Equals [ !Ref Image, "none" ]]
-  UseDefaultConfig: !Equals [ !Ref CustomConfig, "none" ]
-  UseCustomConfig: 
-    Fn::Not: 
-    - !Equals [ !Ref CustomConfig, "none" ]
-  DisableHeadSamplerCondition:
-    Fn::Equals:
-      - !Ref EnableHeadSampler
-      - "false"
-  EnableSpanMetricsCondition:
-    Fn::Equals:
-      - !Ref EnableSpanMetrics
-      - "true"
+  UseImage: !Not [!Equals [!Ref Image, "none"]]
+  UseDefaultConfig: !Equals [!Ref ConfigSource, "template"]
+  UseS3Config: !Equals [!Ref ConfigSource, "s3"]
+  UseSSMConfig: !Equals [!Ref ConfigSource, "ssm"]
+  UseTemplateOrS3Config: !Or [!Equals [!Ref ConfigSource, "template"], !Equals [!Ref ConfigSource, "s3"]]
+  DisableHeadSamplerCondition: !Equals [!Ref EnableHeadSampler, "false"]
+  EnableSpanMetricsCondition: !Equals [!Ref EnableSpanMetrics, "true"]
   EnableTracesDBCondition:
     Fn::And:
-      - Fn::Equals:
-          - !Ref EnableTracesDB
-          - "true"
-      - Fn::Equals:
-          - !Ref EnableSpanMetrics
-          - "true"
+      - !Equals [!Ref EnableTracesDB, "true"]
+      - !Equals [!Ref EnableSpanMetrics, "true"]
   EnableHealthCheck: !Equals [!Ref HealthCheckEnabled, "true"]
 
 Rules:
-  ValidateTaskExecutionRole:
+
+  ValidateS3Parameters:
     Assertions:
       - Assert:
           Fn::Or:
-            - Fn::Equals:
-                - Ref: CustomConfig
-                - "none"
             - Fn::Not:
                 - Fn::Equals:
-                    - Ref: TaskExecutionRoleARN
-                    - "Default"
-        AssertDescription: "TaskExecutionRoleARN cannot be 'Default' if CustomConfig is set to a value other than 'none'."
+                    - !Ref ConfigSource
+                    - "s3"
+            - Fn::Not:
+                - Fn::Equals:
+                    - !Ref S3ConfigBucket
+                    - ""
+            - Fn::Not:
+                - Fn::Equals:
+                    - !Ref S3ConfigKey
+                    - ""
+        AssertDescription: "S3ConfigBucket and S3ConfigKey must be provided when ConfigSource is 's3'."
+
+  ValidateSSMParameters:
+    Assertions:
+      - Assert:
+          Fn::Or:
+            - Fn::Not:
+                - Fn::Equals:
+                    - !Ref ConfigSource
+                    - "ssm"
+            - Fn::Not:
+                - Fn::Equals:
+                    - !Ref CustomConfig
+                    - "none"
+        AssertDescription: "CustomConfig must be provided when ConfigSource is 'ssm'."
+
+
 
 Mappings:
   Otel:
@@ -906,7 +1041,10 @@ Resources:
         - Name: coralogix-otel-agent
           Cpu: 0
           Memory: !Ref Memory
-          Command: ["--config", "env:OTEL_CONFIG"]
+          Command: !If
+            - UseS3Config
+            - ["--config", !Sub "s3://${S3ConfigBucket}.s3.${AWS::Region}.amazonaws.com/${S3ConfigKey}"]
+            - ["--config", "env:OTEL_CONFIG"]
           Image: !If
             - UseImage
             - !Ref Image
@@ -999,11 +1137,157 @@ Resources:
                         - !FindInMap [Otel, PipelineSamplingWithSpanMetrics, Value]
                         - !FindInMap [Otel, PipelineSamplingOnly, Value]
 
+  # Task Definition for S3 configuration
+  OtelTaskDefinitionS3: 
+    Type: AWS::ECS::TaskDefinition
+    Condition: UseS3Config
+    Properties:
+      ExecutionRoleArn: !Ref OtelTaskExecutionRole
+      TaskRoleArn: !Ref OtelTaskExecutionRole
+      Family: opentelemetry
+      RequiresCompatibilities:
+        - EC2
+      NetworkMode: host
+      Volumes:
+        - Name: hostfs
+          Host:
+            SourcePath: "/var/lib/docker/"
+  
+        - Name: docker-socket
+          Host:
+            SourcePath: /var/run/docker.sock
+
+      ContainerDefinitions:
+        - Name: coralogix-otel-agent
+          Cpu: 0
+          Memory: !Ref Memory
+          Command: ["--config", !Sub "s3://${S3ConfigBucket}.s3.${AWS::Region}.amazonaws.com/${S3ConfigKey}"]
+          Image: !If
+            - UseImage
+            - !Ref Image
+            - !Sub "coralogixrepo/coralogix-otel-collector:${CDOTImageVersion}"
+
+          Essential: true
+          HealthCheck: !If
+            - EnableHealthCheck
+            - Command:
+                - "/healthcheck"
+              Interval: !Ref HealthCheckInterval
+              Timeout: !Ref HealthCheckTimeout
+              Retries: !Ref HealthCheckRetries
+              StartPeriod: !Ref HealthCheckStartPeriod
+            - !Ref AWS::NoValue
+
+          PortMappings:
+            # otel grpc endpoint
+            - HostPort: 4317
+              Protocol: tcp
+              AppProtocol: grpc
+              ContainerPort: 4317
+            
+            # otel http endpoint
+            - HostPort: 4318
+              Protocol: tcp
+              ContainerPort: 4318
+
+            # otel metrics endpoint
+            - HostPort: 8888
+              Protocol: tcp
+              ContainerPort: 8888
+
+            # pprof extension default port
+            - HostPort: 1777
+              Protocol: tcp
+              ContainerPort: 1777
+
+          # Privileged required to access certain host metrics
+          Privileged: true
+
+          MountPoints:
+            - SourceVolume: hostfs
+              ContainerPath: "/hostfs/var/lib/docker"
+              ReadOnly: True
+
+            - SourceVolume: docker-socket
+              ContainerPath: /var/run/docker.sock
+
+          Environment:
+            - Name: CORALOGIX_DOMAIN
+              Value: !FindInMap [CoralogixRegionMap, !Ref CoralogixRegion, Domain]
+           
+            - Name: PRIVATE_KEY
+              Value: !Ref CoralogixApiKey
+
+            - Name: APP_NAME
+              Value: !Ref DefaultApplicationName
+
+            - Name: SUB_SYS
+              Value: !Ref DefaultSubsystemName
+              
+            - Name: SAMPLING_PERCENTAGE
+              Value: !Ref SamplingPercentage
+
+            - Name: SAMPLER_MODE
+              Value: !Ref SamplerMode
+
+  # IAM Role for S3 access (only created when ConfigSource=s3)
+  OtelTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: UseS3Config
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-otel-task-execution-role"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: S3ReadAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource: !Sub "arn:aws:s3:::${S3ConfigBucket}/*"
+
+  # IAM Role for SSM access (only created when ConfigSource=ssm)
+  OtelTaskExecutionRoleSSM:
+    Type: AWS::IAM::Role
+    Condition: UseSSMConfig
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-otel-task-execution-role-ssm"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      Policies:
+        - PolicyName: SSMReadAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource: !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${CustomConfig}"
+
   OtelTaskDefinitionCustom: 
     Type: AWS::ECS::TaskDefinition
-    Condition: UseCustomConfig
+    Condition: UseSSMConfig
     Properties:
-      ExecutionRoleArn: !Ref TaskExecutionRoleARN
+      ExecutionRoleArn: !Ref OtelTaskExecutionRoleSSM
+      TaskRoleArn: !Ref OtelTaskExecutionRoleSSM
       Family: opentelemetry
       RequiresCompatibilities:
         - EC2
@@ -1092,7 +1376,10 @@ Resources:
 
           Secrets:
             - Name: OTEL_CONFIG
-              ValueFrom: !Ref CustomConfig
+              ValueFrom: !If
+                - UseSSMConfig
+                - !Ref CustomConfig
+                - !Ref AWS::NoValue
 
   ECSService:
     Type: 'AWS::ECS::Service'
@@ -1120,9 +1407,35 @@ Resources:
       EnableECSManagedTags: true
       TaskDefinition: !Ref OtelTaskDefinition
 
-  ECSServiceCustom:
+  ECSServiceS3:
     Type: 'AWS::ECS::Service'
-    Condition: UseCustomConfig
+    Condition: UseS3Config
+    Properties:
+      Cluster: !Ref ClusterName
+      LaunchType: EC2
+      ServiceName: coralogix-otel-agent
+      SchedulingStrategy: DAEMON
+      DeploymentConfiguration:
+        MaximumPercent: 100
+        MinimumHealthyPercent: 0
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      DeploymentController:
+        Type: ECS
+      ServiceConnectConfiguration:
+        Enabled: false
+      PlacementStrategies: []
+      PlacementConstraints: []
+      Tags:
+        - Key: 'ecs:service:stackId'
+          Value: !Ref 'AWS::StackId'
+      EnableECSManagedTags: true
+      TaskDefinition: !Ref OtelTaskDefinitionS3
+
+  ECSServiceSSM:
+    Type: 'AWS::ECS::Service'
+    Condition: UseSSMConfig
     Properties:
       Cluster: !Ref ClusterName
       LaunchType: EC2


### PR DESCRIPTION
# Description

Parameter store has a character limit which prevent using any otel config, so added s3 provider support.

- Reorganise the cloud formation parameters order.
- Added a selector for otel conf as template/s3/Parameter-Store.
- TaskRoleARN is created on the fly for both s3 and parameter store.
- Added a complete example file for s3.
- Updated Readme 

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)