### PR TITLE
fix(coralogix-aws-shipper): add option to preserve custom sns policies

### DIFF
--- a/aws-integrations/aws-shipper-lambda/CHANGELOG.md
+++ b/aws-integrations/aws-shipper-lambda/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.3.12 / 2025-09-16
+### 💡 Enhancements 💡
+- Added `CreateSNSTopicPolicy` parameter to allow users to preserve existing SNS topic policies when using SNS-based integrations (S3, CloudTrail, VpcFlow, CloudFront, S3Csv). Set to `false` to prevent the module from overwriting custom SNS topic policies.
+
 ## v1.3.11 / 2025-08-11
 ### 💡 Enhancements 💡
 - Add support for S3 bucket KMS key using `S3BucketKMSKeyARN`

--- a/aws-integrations/aws-shipper-lambda/README.md
+++ b/aws-integrations/aws-shipper-lambda/README.md
@@ -203,6 +203,45 @@ To receive SNS messages directly to Coralogix, use the `SNSIntegrationTopicARN` 
 | Parameter              | Description                                                                              | Default Value | Required           |
 |------------------------|------------------------------------------------------------------------------------------|---------------|--------------------|
 | SNSIntegrationTopicArn | Provide the ARN of the SNS topic to which you want to subscribe for retrieving messages. |               | :heavy_check_mark: |
+| CreateSNSTopicPolicy   | Whether to create and manage the SNS topic policy. Set to 'false' if you want to manage the policy yourself and preserve existing permissions. | 'true' | :x: |
+
+#### Custom SNS Topic Policy Management
+
+Set `CreateSNSTopicPolicy = 'false'` to preserve existing SNS topic policies:
+
+```yaml
+Parameters:
+  CreateSNSTopicPolicy: 'false'
+  SNSIntegrationTopicArn: 'arn:aws:sns:us-east-1:123456789012:your-existing-sns-topic'
+  # ... other configuration
+```
+
+##### Required Permissions
+
+When `CreateSNSTopicPolicy = 'false'`, include this permission in your SNS topic policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Action": "SNS:Publish",
+      "Resource": "arn:aws:sns:REGION:ACCOUNT-ID:TOPIC-NAME",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:s3:::YOUR-S3-BUCKET-NAME"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Note**: This only applies to S3-based integrations (S3, CloudTrail, VpcFlow, CloudFront, S3Csv). Direct SNS integration (`IntegrationType = "Sns"`) does not create SNS topic policies.
 
 ### SQS configuration
 

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -67,6 +67,7 @@ Metadata:
           default: SNS configuration
         Parameters:
           - SNSIntegrationTopicArn
+          - CreateSNSTopicPolicy
       - Label:
           default: SQS configuration
         Parameters:
@@ -256,6 +257,13 @@ Parameters:
     Description: The ARN of SNS topic to subscribe to retrieving messages
     # placeholder value to avoid cfn-lint issues
     Default: 'arn:aws:sns:us-east-1:123456789012:placeholder'
+  CreateSNSTopicPolicy:
+    Type: String
+    Description: Whether to create and manage the SNS topic policy. Set to 'false' if you want to manage the policy yourself and preserve existing permissions.
+    Default: 'true'
+    AllowedValues:
+      - 'true'
+      - 'false'
   KinesisStreamArn:
     Type: String
     Description: The ARN of Kinesis stream to subscribe to retrieving messages
@@ -614,6 +622,13 @@ Resources:
             Action:
               - 'sns:Publish'
             Resource: !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*'
+          - Effect: Allow
+            Action:
+              - 'sns:SetTopicAttributes'
+              - 'sns:GetTopicAttributes'
+              - 'sns:AddPermission'
+              - 'sns:RemovePermission'
+            Resource: !Sub 'arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*'
           - !If
             # S3 Policy
             - S3BucketNameIsSet
@@ -913,6 +928,7 @@ Resources:
         SQSTopicArn: !Ref SQSTopicArn
         SQSIntegrationTopicArn: !Ref SQSIntegrationTopicArn
         SNSIntegrationTopicArn: !Ref SNSIntegrationTopicArn
+        CreateSNSTopicPolicy: !Ref CreateSNSTopicPolicy
         KinesisStreamArn: !Ref KinesisStreamArn
         IntegrationType: !Ref IntegrationType
         CloudWatchLogGroupName: !Ref CloudWatchLogGroupName


### PR DESCRIPTION
# Description

Added a new create_sns_topic_policy variable to the coralogix-aws-shipper module to allow users to preserve existing SNS topic policies when using SNS-based integrations. This addresses the issue where the module would overwrite custom SNS topic policies with its own restrictive policy.

The variable defaults to true (maintaining backward compatibility) but can be set to false to prevent the module from creating or managing SNS topic policies, allowing users to maintain their own custom policies.


# Checklist:
- [ v I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)