### PR TITLE
fix(aws-shipper-lambda): correct Private Link endpoints

### DIFF
--- a/aws-integrations/aws-shipper-lambda/CHANGELOG.md
+++ b/aws-integrations/aws-shipper-lambda/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.7 / 2026-04-05
+### 🧰 Bug fixes 🧰
+- **Private Link + Custom domain**: Private ingress must use the region-prefixed Coralogix domain in the hostname, e.g. `https://ingress.private.ap1.coralogix.com`, not the team login suffix alone (e.g. `ingress.private.coralogix.in`). See [Coralogix Endpoints](https://coralogix.com/docs/integrations/coralogix-endpoints/) and [PrivateLink endpoints and deployment](https://coralogix.com/docs/integrations/aws/aws-privatelink/endpoints-deployment/). When `CoralogixRegion` is `Custom` and Private Link is enabled, `CORALOGIX_ENDPOINT` now maps known vanity `CustomDomain` values to the matching `*.coralogix.com` domain so `ingress.private.${domain}` matches documented Private DNS. Previously the template substituted `CustomDomain` directly, producing incorrect hostnames. Unlisted domains still use `CustomDomain` unchanged. Requires the `AWS::LanguageExtensions` transform for `Fn::FindInMap` with `DefaultValue` and a dynamic map key.
+
 ## v1.4.6 / 2026-03-17
 ### 💡 Enhancements 💡
 - **Kinesis batching performance fix**: Kinesis records are now collected and sent in a single batched API call instead of being processed sequentially. This significantly improves throughput for high-volume Kinesis streams (e.g., 700 records now result in ~1 API call instead of ~700).

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
+Transform:
+  - AWS::Serverless-2016-10-31
+  - AWS::LanguageExtensions
 Description: |
   Send logs and metrics to Coralogix from AWS (S3, Cloudtrail, Cloudwatch, msk, SNS, SQS, Kinesis and more)
   Please report any issues to: github.com/coralogix/coralogix-aws-shipper/issues
@@ -463,6 +465,24 @@ Mappings:
       Domain: us2.coralogix.com
     Custom:
       Domain: ""
+  # Maps vanity domains (dots replaced with dashes) to region-prefixed Private Link domains.
+  # Used with AWS::LanguageExtensions to resolve: Fn::FindInMap with Fn::Join/Fn::Split as key.
+  # Truly custom domains not in this map fall back to DefaultValue (the raw CustomDomain).
+  VanityToPrivateLinkDomainMap:
+    coralogix-us:
+      Domain: us1.coralogix.com
+    cx498-coralogix-com:
+      Domain: us2.coralogix.com
+    coralogix-com:
+      Domain: eu1.coralogix.com
+    eu2-coralogix-com:
+      Domain: eu2.coralogix.com
+    coralogix-in:
+      Domain: ap1.coralogix.com
+    coralogixsg-com:
+      Domain: ap2.coralogix.com
+    ap3-coralogix-com:
+      Domain: ap3.coralogix.com
 Conditions:
   # DLQ conditions
   DLQEnabled: !Equals [!Ref EnableDLQ, 'true']
@@ -863,7 +883,11 @@ Resources:
               - IsPrivateLink
               - !Sub
                 - https://ingress.private.${domain}
-                - domain: !Ref CustomDomain
+                - domain: !FindInMap
+                    - VanityToPrivateLinkDomainMap
+                    - !Join ['-', !Split ['.', !Ref CustomDomain]]
+                    - Domain
+                    - DefaultValue: !Ref CustomDomain
               - !Sub
                 - https://ingress.${domain}
                 - domain: !Ref CustomDomain
@@ -1030,7 +1054,11 @@ Resources:
             - IsPrivateLink
             - !Sub
               - https://ingress.private.${domain}
-              - domain: !Ref CustomDomain
+              - domain: !FindInMap
+                  - VanityToPrivateLinkDomainMap
+                  - !Join ['-', !Split ['.', !Ref CustomDomain]]
+                  - Domain
+                  - DefaultValue: !Ref CustomDomain
             - !Sub
               - https://ingress.${domain}
               - domain: !Ref CustomDomain


### PR DESCRIPTION
# Description
[CDS-2842](https://coralogix.atlassian.net/browse/CDS-2842)

When CoralogixRegion is Custom and Private Link is enabled, the template previously built https://ingress.private.${CustomDomain} using the raw login/vanity suffix (for example coralogix.in). 
Documented Private DNS uses the region-prefixed host on *.coralogix.com (for example ingress.private.ap1.coralogix.com). This change maps known vanity domains to the correct region domain for the private ingress URL; unknown domains still use CustomDomain unchanged.

Adds AWS::LanguageExtensions so Fn::FindInMap can use a dynamic key (from CustomDomain) with DefaultValue for the fallback.

# Checklist:
- x[ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

[CDS-2842]: https://coralogix.atlassian.net/browse/CDS-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ