### PR TITLE
fix(aws-shipper-lambda): Private Link vanity mapping + correct transform order + v1.4.7

### DIFF
--- a/aws-integrations/aws-shipper-lambda/CHANGELOG.md
+++ b/aws-integrations/aws-shipper-lambda/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.4.7 / 2026-04-05
 ### 🧰 Bug fixes 🧰
 - **Private Link + Custom domain**: Private ingress must use the region-prefixed Coralogix domain in the hostname, e.g. `https://ingress.private.ap1.coralogix.com`, not the team login suffix alone (e.g. `ingress.private.coralogix.in`). See [Coralogix Endpoints](https://coralogix.com/docs/integrations/coralogix-endpoints/) and [PrivateLink endpoints and deployment](https://coralogix.com/docs/integrations/aws/aws-privatelink/endpoints-deployment/). When `CoralogixRegion` is `Custom` and Private Link is enabled, `CORALOGIX_ENDPOINT` now maps known vanity `CustomDomain` values to the matching `*.coralogix.com` domain so `ingress.private.${domain}` matches documented Private DNS. Previously the template substituted `CustomDomain` directly, producing incorrect hostnames. Unlisted domains still use `CustomDomain` unchanged. Requires the `AWS::LanguageExtensions` transform for `Fn::FindInMap` with `DefaultValue` and a dynamic map key.
+- **Transform order + SAR version**: `AWS::LanguageExtensions` is listed before `AWS::Serverless-2016-10-31` so extended `Fn::FindInMap` resolves before SAM processing (otherwise vanity-to-region mapping can fall back to raw `CustomDomain` in deployed stacks). `SemanticVersion` is set to **1.4.7** to match this release.
 
 ## v1.4.6 / 2026-03-17
 ### 💡 Enhancements 💡

--- a/aws-integrations/aws-shipper-lambda/CHANGELOG.md
+++ b/aws-integrations/aws-shipper-lambda/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.4.7 / 2026-04-05
+### 🧰 Bug fixes 🧰
+- **Private Link + Custom domain**: Private ingress must use the region-prefixed Coralogix domain in the hostname, e.g. `https://ingress.private.ap1.coralogix.com`, not the team login suffix alone (e.g. `ingress.private.coralogix.in`). See [Coralogix Endpoints](https://coralogix.com/docs/integrations/coralogix-endpoints/) and [PrivateLink endpoints and deployment](https://coralogix.com/docs/integrations/aws/aws-privatelink/endpoints-deployment/). When `CoralogixRegion` is `Custom` and Private Link is enabled, `CORALOGIX_ENDPOINT` now maps known vanity `CustomDomain` values to the matching `*.coralogix.com` domain so `ingress.private.${domain}` matches documented Private DNS. Previously the template substituted `CustomDomain` directly, producing incorrect hostnames. Unlisted domains still use `CustomDomain` unchanged. Requires the `AWS::LanguageExtensions` transform for `Fn::FindInMap` with `DefaultValue` and a dynamic map key.
+
 ## v1.4.6 / 2026-03-17
 ### 💡 Enhancements 💡
 - **Kinesis batching performance fix**: Kinesis records are now collected and sent in a single batched API call instead of being processed sequentially. This significantly improves throughput for high-volume Kinesis streams (e.g., 700 records now result in ~1 API call instead of ~700).

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1,5 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Transform: AWS::Serverless-2016-10-31
+Transform:
+  - AWS::Serverless-2016-10-31
+  - AWS::LanguageExtensions
 Description: |
   Send logs and metrics to Coralogix from AWS (S3, Cloudtrail, Cloudwatch, msk, SNS, SQS, Kinesis and more)
   Please report any issues to: github.com/coralogix/coralogix-aws-shipper/issues
@@ -463,6 +465,24 @@ Mappings:
       Domain: us2.coralogix.com
     Custom:
       Domain: ""
+  # Maps vanity domains (dots replaced with dashes) to region-prefixed Private Link domains.
+  # Used with AWS::LanguageExtensions to resolve: Fn::FindInMap with Fn::Join/Fn::Split as key.
+  # Truly custom domains not in this map fall back to DefaultValue (the raw CustomDomain).
+  VanityToPrivateLinkDomainMap:
+    coralogix-us:
+      Domain: us1.coralogix.com
+    cx498-coralogix-com:
+      Domain: us2.coralogix.com
+    coralogix-com:
+      Domain: eu1.coralogix.com
+    eu2-coralogix-com:
+      Domain: eu2.coralogix.com
+    coralogix-in:
+      Domain: ap1.coralogix.com
+    coralogixsg-com:
+      Domain: ap2.coralogix.com
+    ap3-coralogix-com:
+      Domain: ap3.coralogix.com
 Conditions:
   # DLQ conditions
   DLQEnabled: !Equals [!Ref EnableDLQ, 'true']
@@ -863,7 +883,11 @@ Resources:
               - IsPrivateLink
               - !Sub
                 - https://ingress.private.${domain}
-                - domain: !Ref CustomDomain
+                - domain: !FindInMap
+                    - VanityToPrivateLinkDomainMap
+                    - !Join ['-', !Split ['.', !Ref CustomDomain]]
+                    - Domain
+                    - DefaultValue: !Ref CustomDomain
               - !Sub
                 - https://ingress.${domain}
                 - domain: !Ref CustomDomain
@@ -1030,7 +1054,11 @@ Resources:
             - IsPrivateLink
             - !Sub
               - https://ingress.private.${domain}
-              - domain: !Ref CustomDomain
+              - domain: !FindInMap
+                  - VanityToPrivateLinkDomainMap
+                  - !Join ['-', !Split ['.', !Ref CustomDomain]]
+                  - Domain
+                  - DefaultValue: !Ref CustomDomain
             - !Sub
               - https://ingress.${domain}
               - domain: !Ref CustomDomain

--- a/aws-integrations/aws-shipper-lambda/template.yaml
+++ b/aws-integrations/aws-shipper-lambda/template.yaml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform:
-  - AWS::Serverless-2016-10-31
   - AWS::LanguageExtensions
+  - AWS::Serverless-2016-10-31
 Description: |
   Send logs and metrics to Coralogix from AWS (S3, Cloudtrail, Cloudwatch, msk, SNS, SQS, Kinesis and more)
   Please report any issues to: github.com/coralogix/coralogix-aws-shipper/issues
@@ -26,7 +26,7 @@ Metadata:
       - kinesis
       - cloudfront
     HomePageUrl: https://coralogix.com
-    SemanticVersion: 1.4.6
+    SemanticVersion: 1.4.7
     SourceCodeUrl: https://github.com/coralogix/coralogix-aws-shipper
   AWS::CloudFormation::Interface:
     ParameterGroups:


### PR DESCRIPTION
# Description

Set AWS::LanguageExtensions before AWS::Serverless-2016-10-31 so extended Fn::FindInMap (dynamic key + DefaultValue) resolves before SAM; avoids wrong CORALOGIX_ENDPOINT (e.g. still ingress.private.coralogix.in instead of ingress.private.ap1.coralogix.com).

Bump SemanticVersion to 1.4.7 to match CHANGELOG
# Checklist:
- [ x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)