### PR TITLE
fix(ecs-ec2): prevent wildcard S3 IAM permissions when profiling disabled

### DIFF
--- a/opentelemetry/ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/ecs-ec2/CHANGELOG.md
@@ -5,6 +5,12 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 1.0.10 / 2026-04-06
+- [Bug fix] Fixed IAM S3 policies granting wildcard access when profiling is disabled (empty bucket param resolved to `arn:aws:s3:::/*`).
+- [Update] Profiling S3 bucket ARNs are now conditionally included in IAM policies only when `ProfilingEnabled` is true.
+- [Update] Added CloudFormation Rules to validate `ProfilingS3ConfigBucket` and `ProfilingS3ConfigKey` are non-empty when profiling is enabled.
+- [Update] Moved profiling S3 parameters into the "Profiling Configuration" parameter group for consistency.
+
 ### 1.0.9 / 2026-03-17
 - [Update] Removed `template-multi-config.yaml`; template now uses S3-only configuration (aligned with Coralogix UI deployment flow).
 - [Update] Removed `examples` folder and `comprehensive-config.yaml`; canonical config is maintained in the [telemetry-shippers integration chart](https://github.com/coralogix/telemetry-shippers/tree/master/otel-ecs-ec2).

--- a/opentelemetry/ecs-ec2/template.yaml
+++ b/opentelemetry/ecs-ec2/template.yaml
@@ -21,13 +21,12 @@ Metadata:
           - S3ConfigBucket
           - S3ConfigKey
 
-          - ProfilingS3ConfigBucket
-          - ProfilingS3ConfigKey
-
       - Label:
           default: "Profiling Configuration"
         Parameters:
           - ProfilingEnabled
+          - ProfilingS3ConfigBucket
+          - ProfilingS3ConfigKey
           - ProfilingMemory
       
       - Label:
@@ -214,6 +213,15 @@ Parameters:
       This is separate from the execution role which is used by ECS to pull images and retrieve secrets.
     Default: ""
 
+Rules:
+  ProfilingS3ConfigRequired:
+    RuleCondition: !Equals [!Ref ProfilingEnabled, "true"]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref ProfilingS3ConfigBucket, ""]]
+        AssertDescription: "ProfilingS3ConfigBucket is required when ProfilingEnabled is true."
+      - Assert: !Not [!Equals [!Ref ProfilingS3ConfigKey, ""]]
+        AssertDescription: "ProfilingS3ConfigKey is required when ProfilingEnabled is true."
+
 Conditions:
   UseImage: !Not [!Equals [!Ref Image, "none"]]
   EnableHealthCheck: !Equals [!Ref HealthCheckEnabled, "true"]
@@ -355,13 +363,19 @@ Resources:
                   - s3:GetObjectVersion
                 Resource:
                   - !Sub "arn:aws:s3:::${S3ConfigBucket}/*"
-                  - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}/*"
+                  - !If
+                    - EnableProfiling
+                    - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}/*"
+                    - !Ref AWS::NoValue
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
                   - !Sub "arn:aws:s3:::${S3ConfigBucket}"
-                  - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}"
+                  - !If
+                    - EnableProfiling
+                    - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}"
+                    - !Ref AWS::NoValue
 
   # IAM Role for task runtime (container operations - minimal permissions)
   # Only created if no custom task role is provided
@@ -388,13 +402,19 @@ Resources:
                   - s3:GetObjectVersion
                 Resource:
                   - !Sub "arn:aws:s3:::${S3ConfigBucket}/*"
-                  - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}/*"
+                  - !If
+                    - EnableProfiling
+                    - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}/*"
+                    - !Ref AWS::NoValue
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
                   - !Sub "arn:aws:s3:::${S3ConfigBucket}"
-                  - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}"
+                  - !If
+                    - EnableProfiling
+                    - !Sub "arn:aws:s3:::${ProfilingS3ConfigBucket}"
+                    - !Ref AWS::NoValue
 
   ECSService:
     Type: 'AWS::ECS::Service'


### PR DESCRIPTION
## Summary
- **Fix wildcard IAM permissions**: When `ProfilingEnabled=false` (default), empty `ProfilingS3ConfigBucket` resolved to `arn:aws:s3:::/*`, granting access to all S3 buckets. Profiling bucket ARNs are now conditionally included via `!If` only when profiling is enabled.
- **Add CloudFormation Rules**: Validate that `ProfilingS3ConfigBucket` and `ProfilingS3ConfigKey` are non-empty when `ProfilingEnabled=true`, preventing broken deployments.
- **Group profiling parameters**: Moved all profiling-related params under "Profiling Configuration" in the CloudFormation console.

Fixes issues introduced in #217.

## Test plan
- [x] Deployed stack with `ProfilingEnabled=false` — IAM policy only contains config bucket ARN, no wildcards
- [x] Attempted deploy with `ProfilingEnabled=true` and empty profiling S3 params — correctly rejected by CloudFormation Rules
- [x] Base agent service runs ACTIVE 1/1
- Tested on cluster: `arn:aws:ecs:us-east-1:035955823196:cluster/otel-test-cluster`