### PR TITLE
docs: add firehose-logs, firehose-metrics, eventbridge READMEs to dispatch trigger

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -7,6 +7,9 @@ on:
       - master
     paths:
       - 'opentelemetry/ecs-ec2/README.md'
+      - 'aws-integrations/eventbridge/README.md'
+      - 'aws-integrations/firehose-logs/README.md'
+      - 'aws-integrations/firehose-metrics/README.md'
 
 jobs:
   trigger_action:


### PR DESCRIPTION
## Summary

- Adds `aws-integrations/firehose-logs/README.md`, `aws-integrations/firehose-metrics/README.md`, and `aws-integrations/eventbridge/README.md` to the `trigger-docs-sync.yml` dispatch trigger
- These CloudFormation template READMEs are now synced into the Coralogix docs repo as hybrid-sync external pages

## Why

These READMEs are referenced from Coralogix documentation pages as external synced content. Without these paths in the dispatch trigger, README updates would not propagate to the docs site on push to master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)