### PR TITLE
docs: add TW as blocking reviewer for opentelemetry/ecs-ec2/README.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
 * @coralogix/team-ido
+
+# Technical writers own documentation
+opentelemetry/ecs-ec2/README.md @coralogix/team-technical-writers


### PR DESCRIPTION
## Why

The `opentelemetry/ecs-ec2/README.md` file is synced automatically into the Coralogix documentation portal via `external_repos.json`. Any change to this file triggers an immediate docs redeploy.

Adding `@coralogix/team-technical-writers` as a required reviewer ensures no change to synced docs content merges without TW sign-off.

## Change

Adds `@coralogix/team-technical-writers` to `.github/CODEOWNERS` for `opentelemetry/ecs-ec2/README.md`.

## Note

This replaces PR #227, which was accidentally closed during a branch operation. Apologies for the noise.