### PR TITLE
feat: cloudformation template for Cloud Accounts feature

### DIFF
--- a/cloud-accounts/automatic/CHANGELOG.md
+++ b/cloud-accounts/automatic/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [1.0.0] - 2026-06-18
+
+### Added
+
+- Add a CloudFormation template for creating the automatic cloud account IAM role with Coralogix region mapping, custom endpoint parameters, optional external ID support, and the default role name `coralogix-cloud-account`.

--- a/cloud-accounts/automatic/README.md
+++ b/cloud-accounts/automatic/README.md
@@ -1,0 +1,39 @@
+# Coralogix Cloud Account Automatic Integration
+
+This CloudFormation template creates a named IAM role that allows Coralogix to collect AWS account metrics and is meant to be used via Cloud Accounts feature in Coralogix.
+
+The published template URL is:
+
+```text
+https://cgx-cloudformation-templates.s3.amazonaws.com/cloud-accounts/automatic/template.yaml
+```
+
+## Prerequisites
+
+* AWS account permissions to create IAM roles and attach AWS managed policies.
+* The Coralogix company ID for your account.
+* `CAPABILITY_NAMED_IAM` when deploying, because the stack creates a named IAM role.
+
+## IAM Permissions
+
+This template intentionally attaches broad AWS managed policies, including IAM, S3, Kinesis Data Firehose, CloudWatch, Resource Explorer, and read-only account access. The automatic Cloud Accounts role is used by Coralogix to create supporting IAM roles and AWS resources required for Firehose metric streaming, not only to read existing metrics. A future template will provide a narrower permission model for deployments that do not require Coralogix to create those supporting resources.
+
+## Parameters
+
+| Parameter | Description | Default value | Required |
+|---|---|---|---|
+| `CoralogixRegion` | Coralogix region for your account. Allowed values are `staging`, `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `gov1`, and `CustomEndpoint`. | `EU1` | :heavy_check_mark: |
+| `CoralogixCompanyId` | Numeric Coralogix company ID. Used to build `<ExternalIdSecret>@<CoralogixCompanyId>` when `ExternalIdSecret` is provided. | | :heavy_check_mark: |
+| `RoleName` | Name of the IAM role to create. | `coralogix-cloud-account` | |
+| `ExternalIdSecret` | Optional external ID secret for `sts:AssumeRole`. When blank, the trust policy has no external ID condition and the `ExternalId` output is omitted. | | |
+| `CustomAWSAccountId` | Custom 12-digit Coralogix AWS account ID. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
+| `CustomRoleSuffix` | Custom suffix for the trusted `coralogix-ingestion-<suffix>` role. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
+
+For BYOC (Bring Your Own Cloud) Coralogix environments, use `CoralogixRegion=CustomEndpoint` and provide both `CustomAWSAccountId` and `CustomRoleSuffix`.
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `CoralogixAwsMetricsRoleArn` | ARN of the IAM role created for Coralogix. |
+| `ExternalId` | `<ExternalIdSecret>@<CoralogixCompanyId>`. Present only when `ExternalIdSecret` is not blank. |

--- a/cloud-accounts/automatic/template.yaml
+++ b/cloud-accounts/automatic/template.yaml
@@ -1,0 +1,163 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates an IAM role allowing Coralogix to collect metrics from your AWS account.
+
+Metadata:
+  SemanticVersion: 1.0.0
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Coralogix configuration
+        Parameters:
+          - CoralogixRegion
+          - CoralogixCompanyId
+          - CustomAWSAccountId
+          - CustomRoleSuffix
+      - Label:
+          default: Role configuration
+        Parameters:
+          - RoleName
+          - ExternalIdSecret
+
+Parameters:
+  CoralogixRegion:
+    Type: String
+    Default: EU1
+    Description: The Coralogix region for your account. Select CustomEndpoint to supply a custom trusted AWS account ID and role suffix.
+    AllowedValues:
+      - staging
+      - EU1
+      - EU2
+      - AP1
+      - AP2
+      - AP3
+      - US1
+      - US2
+      - gov1
+      - CustomEndpoint
+  CoralogixCompanyId:
+    Type: String
+    Description: Your Coralogix company ID. Used to build the external ID when ExternalIdSecret is provided.
+    AllowedPattern: "[0-9]+"
+    MaxLength: 64
+  RoleName:
+    Type: String
+    Default: coralogix-cloud-account
+    Description: The name of the IAM role that will be created.
+    AllowedPattern: '[\w+=,.@-]+'
+    MaxLength: 64
+  ExternalIdSecret:
+    Type: String
+    Default: ""
+    Description: Optional ExternalIdSecret to increase security for sts:AssumeRole.
+    AllowedPattern: '^$|^[\w+=,.:\/-]+$'
+    MaxLength: 64
+  CustomAWSAccountId:
+    Type: String
+    Default: ""
+    Description: Custom Coralogix AWS account ID. Required when CoralogixRegion is CustomEndpoint.
+    AllowedPattern: "^$|^[0-9]{12}$"
+  CustomRoleSuffix:
+    Type: String
+    Default: ""
+    Description: Custom suffix for the trusted coralogix-ingestion role. Required when CoralogixRegion is CustomEndpoint.
+    AllowedPattern: '[\w+=,.@-]*'
+    MaxLength: 44
+
+Mappings:
+  CoralogixEnvironment:
+    staging:
+      AwsAccountId: "233221153619"
+      RoleSuffix: stg1
+    EU1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: eu1
+    EU2:
+      AwsAccountId: "625240141681"
+      RoleSuffix: eu2
+    AP1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: ap1
+    AP2:
+      AwsAccountId: "625240141681"
+      RoleSuffix: ap2
+    AP3:
+      AwsAccountId: "025066248247"
+      RoleSuffix: ap3
+    US1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: us1
+    US2:
+      AwsAccountId: "739076534691"
+      RoleSuffix: us2
+    gov1:
+      AwsAccountId: "309801239943"
+      RoleSuffix: gov1
+    CustomEndpoint:
+      AwsAccountId: "000000000000"
+      RoleSuffix: custom
+
+Rules:
+  CustomEndpointRequiresAccountIdAndRoleSuffix:
+    RuleCondition: !Equals [!Ref CoralogixRegion, CustomEndpoint]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref CustomAWSAccountId, ""]]
+        AssertDescription: CustomAWSAccountId is required when CoralogixRegion is CustomEndpoint.
+      - Assert: !Not [!Equals [!Ref CustomRoleSuffix, ""]]
+        AssertDescription: CustomRoleSuffix is required when CoralogixRegion is CustomEndpoint.
+
+Conditions:
+  HasExternalId: !Not [!Equals [!Ref ExternalIdSecret, ""]]
+  IsCustomEndpoint: !Equals [!Ref CoralogixRegion, CustomEndpoint]
+
+Resources:
+  CoralogixAwsMetricsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "arn:${AWS::Partition}:iam::${AwsAccountId}:role/coralogix-ingestion-${RoleSuffix}"
+                - AwsAccountId: !If
+                    - IsCustomEndpoint
+                    - !Ref CustomAWSAccountId
+                    - !FindInMap [
+                        CoralogixEnvironment,
+                        !Ref CoralogixRegion,
+                        AwsAccountId,
+                      ]
+                  RoleSuffix: !If
+                    - IsCustomEndpoint
+                    - !Ref CustomRoleSuffix
+                    - !FindInMap [
+                        CoralogixEnvironment,
+                        !Ref CoralogixRegion,
+                        RoleSuffix,
+                      ]
+            Action:
+              - sts:AssumeRole
+            Condition: !If
+              - HasExternalId
+              - StringEquals:
+                  sts:ExternalId: !Sub "${ExternalIdSecret}@${CoralogixCompanyId}"
+              - !Ref "AWS::NoValue"
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonKinesisFirehoseFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSResourceExplorerFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchFullAccessV2
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/IAMFullAccess
+
+Outputs:
+  CoralogixAwsMetricsRoleArn:
+    Description: The ARN of the Coralogix AWS Metrics role.
+    Value: !GetAtt CoralogixAwsMetricsRole.Arn
+  ExternalId:
+    Condition: HasExternalId
+    Description: The ExternalId of the Coralogix AWS Metrics role.
+    Value: !Sub "${ExternalIdSecret}@${CoralogixCompanyId}"


### PR DESCRIPTION
# Description
We had this CloudFormation template generated in the frontend, users would download it and deploy it. We want to eliminate the download step so that they can open AWS console with the template ready to be filled. That's why we're moving the template here with a few adjustments for more parameterization.
<!-- Please describe the changes you made in a few words or sentences. -->

Fixes https://coralogix.atlassian.net/browse/CX-46151

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->
Deployed AWS stack from the template and verified that the frontend works with the deployed role.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
