### PR TITLE
feat(cloud-accounts): version 2 of the template with much less permissions

### DIFF
--- a/cloud-accounts/automatic/CHANGELOG.md
+++ b/cloud-accounts/automatic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.0.0] - 2026-07-03
+
+### Changed
+
+- Remove broad Firehose, S3, CloudWatch, and IAM managed policies from the Coralogix-assumed role.
+- Add `<RoleName>-fh` and `<RoleName>-ms` service roles for Firehose-backed monitoring resources.
+
 ## [1.0.0] - 2026-06-18
 
 ### Added

--- a/cloud-accounts/automatic/README.md
+++ b/cloud-accounts/automatic/README.md
@@ -10,13 +10,19 @@ https://cgx-cloudformation-templates.s3.amazonaws.com/cloud-accounts/automatic/t
 
 ## Prerequisites
 
-* AWS account permissions to create IAM roles and attach AWS managed policies.
+* AWS account permissions to create IAM roles, attach AWS managed policies, and add inline IAM policies.
 * The Coralogix company ID for your account.
 * `CAPABILITY_NAMED_IAM` when deploying, because the stack creates a named IAM role.
 
 ## IAM Permissions
 
-This template intentionally attaches broad AWS managed policies, including IAM, S3, Kinesis Data Firehose, CloudWatch, Resource Explorer, and read-only account access. The automatic Cloud Accounts role is used by Coralogix to create supporting IAM roles and AWS resources required for Firehose metric streaming, not only to read existing metrics. A future template will provide a narrower permission model for deployments that do not require Coralogix to create those supporting resources.
+This template creates three IAM roles:
+
+* `coralogix-cloud-account` by default, or the custom `RoleName` value. Coralogix assumes this role.
+* `<RoleName>-fh`, a service role trusted by Kinesis Data Firehose.
+* `<RoleName>-ms`, a service role trusted by CloudWatch Metric Streams.
+
+The Coralogix-assumed role keeps AWS `ReadOnlyAccess` and `AWSResourceExplorerFullAccess`. An inline policy allows only the actions needed to manage Coralogix-owned `cx-*` Firehose delivery streams, CloudWatch Metric Streams, backup S3 buckets/objects, and to pass the two service roles to their intended AWS services.
 
 ## Parameters
 
@@ -24,7 +30,7 @@ This template intentionally attaches broad AWS managed policies, including IAM, 
 |---|---|---|---|
 | `CoralogixRegion` | Coralogix region for your account. Allowed values are `staging`, `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `gov1`, and `CustomEndpoint`. | `EU1` | :heavy_check_mark: |
 | `CoralogixCompanyId` | Numeric Coralogix company ID. Used to build `<ExternalIdSecret>@<CoralogixCompanyId>` when `ExternalIdSecret` is provided. | | :heavy_check_mark: |
-| `RoleName` | Name of the IAM role to create. | `coralogix-cloud-account` | |
+| `RoleName` | Name of the main IAM role to create. Static Firehose service roles use this name with `-fh` and `-ms` suffixes. | `coralogix-cloud-account` | |
 | `ExternalIdSecret` | Optional external ID secret for `sts:AssumeRole`. When blank, the trust policy has no external ID condition and the `ExternalId` output is omitted. | | |
 | `CustomAWSAccountId` | Custom 12-digit Coralogix AWS account ID. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
 | `CustomRoleSuffix` | Custom suffix for the trusted `coralogix-ingestion-<suffix>` role. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |

--- a/cloud-accounts/automatic/template.yaml
+++ b/cloud-accounts/automatic/template.yaml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: Creates an IAM role allowing Coralogix to collect metrics from your AWS account.
 
 Metadata:
-  SemanticVersion: 1.0.0
+  SemanticVersion: 2.0.0
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -42,9 +42,9 @@ Parameters:
   RoleName:
     Type: String
     Default: coralogix-cloud-account
-    Description: The name of the IAM role that will be created.
+    Description: The name of the main IAM role that will be created. Static Firehose service roles use this name with -fh and -ms suffixes.
     AllowedPattern: '[\w+=,.@-]+'
-    MaxLength: 64
+    MaxLength: 56
   ExternalIdSecret:
     Type: String
     Default: ""
@@ -110,10 +110,65 @@ Conditions:
   IsCustomEndpoint: !Equals [!Ref CoralogixRegion, CustomEndpoint]
 
 Resources:
+  CoralogixFirehoseServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${RoleName}-fh"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: firehose.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CoralogixS3BackupAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:AbortMultipartUpload
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:ListBucket
+                  - s3:ListBucketMultipartUploads
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::cx-*
+                  - !Sub arn:${AWS::Partition}:s3:::cx-*/*
+
+  CoralogixMetricStreamsServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${RoleName}-ms"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: streams.metrics.cloudwatch.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CoralogixFirehosePutAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:PutRecord
+                  - firehose:PutRecordBatch
+                Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/cx-*
+
   CoralogixAwsMetricsRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref RoleName
+      Tags:
+        - Key: CoralogixCloudAccountTemplateVersion
+          Value: "2"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -146,12 +201,53 @@ Resources:
               - !Ref "AWS::NoValue"
       ManagedPolicyArns:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonKinesisFirehoseFullAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSResourceExplorerFullAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchFullAccess
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchFullAccessV2
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/IAMFullAccess
+      Policies:
+        - PolicyName: CoralogixCloudAccountResourceManagement
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: ManageCoralogixFirehoseDeliveryStreams
+                Effect: Allow
+                Action:
+                  - firehose:CreateDeliveryStream
+                  - firehose:DeleteDeliveryStream
+                  - firehose:UpdateDestination
+                Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/cx-*
+              - Sid: ManageCoralogixMetricStreams
+                Effect: Allow
+                Action:
+                  - cloudwatch:PutMetricStream
+                  - cloudwatch:DeleteMetricStream
+                Resource: !Sub arn:${AWS::Partition}:cloudwatch:*:${AWS::AccountId}:metric-stream/cx-*
+              - Sid: ManageCoralogixBackupBuckets
+                Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                  - s3:PutBucketPublicAccessBlock
+                  - s3:DeleteBucket
+                Resource: !Sub arn:${AWS::Partition}:s3:::cx-*
+              - Sid: DeleteCoralogixBackupObjects
+                Effect: Allow
+                Action:
+                  - s3:DeleteObject
+                Resource: !Sub arn:${AWS::Partition}:s3:::cx-*/*
+              - Sid: PassCoralogixFirehoseServiceRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !GetAtt CoralogixFirehoseServiceRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: firehose.amazonaws.com
+              - Sid: PassCoralogixMetricStreamsServiceRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !GetAtt CoralogixMetricStreamsServiceRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: streams.metrics.cloudwatch.amazonaws.com
 
 Outputs:
   CoralogixAwsMetricsRoleArn:


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
Modified the template that's used for Cloud Accounts feature. The updated template requires much less permissions than the old one to improve security. In order to do that we had to generate some service-roles upfront so that's why some new roles for CloudWatch and Firehose were added.

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes https://coralogix.atlassian.net/browse/CX-47650

# How Has This Been Tested?

The template has been created in a stack and tested with new service code that's expecting these changes.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
