### PR TITLE
feat(cloud-accounts): add manual bootstrap template

### DIFF
--- a/cloud-accounts/manual/CHANGELOG.md
+++ b/cloud-accounts/manual/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [1.0.0] - 2026-07-15
+
+### Added
+
+- Add the one-time Manual cloud account bootstrap role with AWS `ReadOnlyAccess`, `AWSResourceExplorerFullAccess`, Coralogix region mapping, custom endpoint parameters, and optional external ID support.
+- Tag the role with `CoralogixCloudAccountTemplateVersion` value `1` for Manual onboarding.
+
+Manual and Automatic template versions are independent release lines. Both templates use the `CoralogixCloudAccountTemplateVersion` IAM tag, and integrations-service interprets its integer value together with the account permission mode.

--- a/cloud-accounts/manual/README.md
+++ b/cloud-accounts/manual/README.md
@@ -1,0 +1,51 @@
+# Coralogix Cloud Account Manual Integration
+
+This CloudFormation template creates the one-time bootstrap IAM role that allows Coralogix to collect AWS account metrics in Manual mode. Terraform or OpenTofu manages the monitoring resources after onboarding.
+
+The published template URL is:
+
+```text
+https://cgx-cloudformation-templates.s3.amazonaws.com/cloud-accounts/manual/template.yaml
+```
+
+## Prerequisites
+
+* AWS account permissions to create a named IAM role and attach AWS managed policies.
+* The Coralogix company ID for your account.
+* `CAPABILITY_NAMED_IAM` when deploying, because the stack creates a named IAM role.
+
+## IAM Permissions
+
+The template creates only `coralogix-cloud-account` by default, or the custom `RoleName` value. Coralogix assumes this role, which has these AWS managed policies:
+
+* `ReadOnlyAccess`
+* `AWSResourceExplorerFullAccess`
+
+The Coralogix-assumed role does not receive the automatic template's resource-management or `iam:PassRole` inline policy. It also does not create the Firehose or Metric Stream service roles.
+
+The customer-controlled identity that runs the generated Terraform or OpenTofu configuration is separate from the Coralogix-assumed role. That execution identity must already be authorized to create, update, and delete the generated IAM, S3, Kinesis Data Firehose, and CloudWatch resources. It must also be authorized to pass the two Terraform-created service roles only to their intended services:
+
+* `<RoleName>-fh` to `firehose.amazonaws.com`
+* `<RoleName>-ms` to `streams.metrics.cloudwatch.amazonaws.com`
+
+Terraform or OpenTofu owns those service roles and all generated Firehose monitoring resources after onboarding.
+
+## Parameters
+
+| Parameter | Description | Default value | Required |
+|---|---|---|---|
+| `CoralogixRegion` | Coralogix region for your account. Allowed values are `staging`, `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `gov1`, and `CustomEndpoint`. | `EU1` | :heavy_check_mark: |
+| `CoralogixCompanyId` | Numeric Coralogix company ID. Used to build `<ExternalIdSecret>@<CoralogixCompanyId>` when `ExternalIdSecret` is provided. | | :heavy_check_mark: |
+| `RoleName` | Name of the IAM role to create for Coralogix. | `coralogix-cloud-account` | |
+| `ExternalIdSecret` | Optional external ID secret for `sts:AssumeRole`. When blank, the trust policy has no external ID condition and the `ExternalId` output is omitted. | | |
+| `CustomAWSAccountId` | Custom 12-digit Coralogix AWS account ID. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
+| `CustomRoleSuffix` | Custom suffix for the trusted `coralogix-ingestion-<suffix>` role. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
+
+For BYOC (Bring Your Own Cloud) Coralogix environments, use `CoralogixRegion=CustomEndpoint` and provide both `CustomAWSAccountId` and `CustomRoleSuffix`.
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `CoralogixAwsMetricsRoleArn` | ARN of the IAM role created for Coralogix. |
+| `ExternalId` | `<ExternalIdSecret>@<CoralogixCompanyId>`. Present only when `ExternalIdSecret` is not blank. |

--- a/cloud-accounts/manual/template.yaml
+++ b/cloud-accounts/manual/template.yaml
@@ -1,0 +1,161 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Creates an IAM role allowing Coralogix to collect metrics from your AWS account.
+
+Metadata:
+  SemanticVersion: 1.0.0
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Coralogix configuration
+        Parameters:
+          - CoralogixRegion
+          - CoralogixCompanyId
+          - CustomAWSAccountId
+          - CustomRoleSuffix
+      - Label:
+          default: Role configuration
+        Parameters:
+          - RoleName
+          - ExternalIdSecret
+
+Parameters:
+  CoralogixRegion:
+    Type: String
+    Default: EU1
+    Description: The Coralogix region for your account. Select CustomEndpoint to supply a custom trusted AWS account ID and role suffix.
+    AllowedValues:
+      - staging
+      - EU1
+      - EU2
+      - AP1
+      - AP2
+      - AP3
+      - US1
+      - US2
+      - gov1
+      - CustomEndpoint
+  CoralogixCompanyId:
+    Type: String
+    Description: Your Coralogix company ID. Used to build the external ID when ExternalIdSecret is provided.
+    AllowedPattern: "[0-9]+"
+    MaxLength: 64
+  RoleName:
+    Type: String
+    Default: coralogix-cloud-account
+    Description: The name of the main IAM role that will be created.
+    AllowedPattern: '[\w+=,.@-]+'
+    MaxLength: 56
+  ExternalIdSecret:
+    Type: String
+    Default: ""
+    Description: Optional ExternalIdSecret to increase security for sts:AssumeRole.
+    AllowedPattern: '^$|^[\w+=,.:\/-]+$'
+    MaxLength: 64
+  CustomAWSAccountId:
+    Type: String
+    Default: ""
+    Description: Custom Coralogix AWS account ID. Required when CoralogixRegion is CustomEndpoint.
+    AllowedPattern: "^$|^[0-9]{12}$"
+  CustomRoleSuffix:
+    Type: String
+    Default: ""
+    Description: Custom suffix for the trusted coralogix-ingestion role. Required when CoralogixRegion is CustomEndpoint.
+    AllowedPattern: '[\w+=,.@-]*'
+    MaxLength: 44
+
+Mappings:
+  CoralogixEnvironment:
+    staging:
+      AwsAccountId: "233221153619"
+      RoleSuffix: stg1
+    EU1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: eu1
+    EU2:
+      AwsAccountId: "625240141681"
+      RoleSuffix: eu2
+    AP1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: ap1
+    AP2:
+      AwsAccountId: "625240141681"
+      RoleSuffix: ap2
+    AP3:
+      AwsAccountId: "025066248247"
+      RoleSuffix: ap3
+    US1:
+      AwsAccountId: "625240141681"
+      RoleSuffix: us1
+    US2:
+      AwsAccountId: "739076534691"
+      RoleSuffix: us2
+    gov1:
+      AwsAccountId: "309801239943"
+      RoleSuffix: gov1
+    CustomEndpoint:
+      AwsAccountId: "000000000000"
+      RoleSuffix: custom
+
+Rules:
+  CustomEndpointRequiresAccountIdAndRoleSuffix:
+    RuleCondition: !Equals [!Ref CoralogixRegion, CustomEndpoint]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref CustomAWSAccountId, ""]]
+        AssertDescription: CustomAWSAccountId is required when CoralogixRegion is CustomEndpoint.
+      - Assert: !Not [!Equals [!Ref CustomRoleSuffix, ""]]
+        AssertDescription: CustomRoleSuffix is required when CoralogixRegion is CustomEndpoint.
+
+Conditions:
+  HasExternalId: !Not [!Equals [!Ref ExternalIdSecret, ""]]
+  IsCustomEndpoint: !Equals [!Ref CoralogixRegion, CustomEndpoint]
+
+Resources:
+  CoralogixAwsMetricsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref RoleName
+      Tags:
+        - Key: CoralogixCloudAccountTemplateVersion
+          Value: "1"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub
+                - "arn:${AWS::Partition}:iam::${AwsAccountId}:role/coralogix-ingestion-${RoleSuffix}"
+                - AwsAccountId: !If
+                    - IsCustomEndpoint
+                    - !Ref CustomAWSAccountId
+                    - !FindInMap [
+                        CoralogixEnvironment,
+                        !Ref CoralogixRegion,
+                        AwsAccountId,
+                      ]
+                  RoleSuffix: !If
+                    - IsCustomEndpoint
+                    - !Ref CustomRoleSuffix
+                    - !FindInMap [
+                        CoralogixEnvironment,
+                        !Ref CoralogixRegion,
+                        RoleSuffix,
+                      ]
+            Action:
+              - sts:AssumeRole
+            Condition: !If
+              - HasExternalId
+              - StringEquals:
+                  sts:ExternalId: !Sub "${ExternalIdSecret}@${CoralogixCompanyId}"
+              - !Ref "AWS::NoValue"
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/ReadOnlyAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSResourceExplorerFullAccess
+
+Outputs:
+  CoralogixAwsMetricsRoleArn:
+    Description: The ARN of the Coralogix AWS Metrics role.
+    Value: !GetAtt CoralogixAwsMetricsRole.Arn
+  ExternalId:
+    Condition: HasExternalId
+    Description: The ExternalId of the Coralogix AWS Metrics role.
+    Value: !Sub "${ExternalIdSecret}@${CoralogixCompanyId}"


### PR DESCRIPTION
# Description

<!-- Please describe the changes you made in a few words or sentences. -->
We already have the cloud-accounts template for fully automated management. This PR adds the template that will be used with manual provisioning with IaC (Terraform or OpenTofu for now). Therefore, this CF template can request much less permissions that then fully automated one.

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes https://coralogix.atlassian.net/browse/CX-28337

# How Has This Been Tested?

Manually deployed and tested together with the code for this new template.

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
