### PR TITLE
feat(opentelemetry): add OBI (eBPF instrumentation) ECS EC2 template

### DIFF
--- a/opentelemetry/obi-ecs-ec2/.env.example
+++ b/opentelemetry/obi-ecs-ec2/.env.example
@@ -1,0 +1,26 @@
+# Copy this file to .env and fill in your values.
+
+CLUSTER_NAME=<your-ecs-cluster-name>
+OBI_IMAGE_VERSION=v0.10.0
+
+# Optional overrides
+AWS_REGION=eu-north-1
+STACK_NAME=coralogix-obi-test
+SERVICE_NAME=coralogix-obi
+CONTEXT_PROPAGATION_MODE=headers,tcp
+OTLP_TRACES_ENDPOINT=http://localhost:4317
+OTLP_METRICS_ENDPOINT=http://localhost:4318
+OBI_IMAGE_REPOSITORY=ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument
+
+# Optional: override the embedded OBI config from S3 (leave empty to use the default)
+S3_BUCKET=
+S3_CONFIG_KEY=
+
+# ECS EC2 instance provisioning (used by make create-ec2-instance / smoke)
+ECS_INSTANCE_PROFILE=ecsInstanceRole
+EC2_INSTANCE_TYPE=t3.medium
+# ECS_EC2_AMI_SSM_PARAM=/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
+# ECS_EC2_AMI_ID=ami-xxxxxxxxxxxxxxxxx
+# EC2_SUBNET_ID=subnet-xxxxxxxxxxxxxxxxx
+# EC2_SECURITY_GROUP_ID=sg-xxxxxxxxxxxxxxxxx
+# EC2_KEY_NAME=your-keypair-name

--- a/opentelemetry/obi-ecs-ec2/CHANGELOG.md
+++ b/opentelemetry/obi-ecs-ec2/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## opentelemetry obi-ecs-ec2
+<!-- To add a new entry write: -->
+<!-- ### version / full date -->
+<!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 0.1.0 / 2026-08-16
+* [Feature] Initial OpenTelemetry eBPF Instrumentation (OBI) ECS EC2 daemon template. Runs OBI (`ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0`) as a privileged, host-PID, host-network `DAEMON` service that instruments every process on the host via eBPF and exports OTLP to the node-local Coralogix collector. Config is embedded by default or loaded from S3.

--- a/opentelemetry/obi-ecs-ec2/Makefile
+++ b/opentelemetry/obi-ecs-ec2/Makefile
@@ -1,0 +1,264 @@
+SHELL := /bin/bash
+
+ENV_FILE ?= .env
+
+ifneq (,$(wildcard $(ENV_FILE)))
+include $(ENV_FILE)
+export
+endif
+
+TEMPLATE_FILE ?= template.yaml
+CONFIG_FILE ?= examples/obi-config.yaml
+STACK_NAME ?= coralogix-obi-test
+AWS_REGION ?= eu-north-1
+SERVICE_NAME ?= coralogix-obi
+OBI_IMAGE_REPOSITORY ?= ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument
+OBI_IMAGE_VERSION ?= v0.10.0
+CONTEXT_PROPAGATION_MODE ?= headers,tcp
+OTLP_TRACES_ENDPOINT ?= http://localhost:4317
+OTLP_METRICS_ENDPOINT ?= http://localhost:4318
+S3_BUCKET ?=
+S3_CONFIG_KEY ?=
+
+ECS_INSTANCE_PROFILE ?= ecsInstanceRole
+ECS_EC2_AMI_SSM_PARAM ?= /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
+ECS_EC2_AMI_ID ?=
+EC2_INSTANCE_TYPE ?= t3.medium
+EC2_SUBNET_ID ?=
+EC2_SECURITY_GROUP_ID ?=
+EC2_KEY_NAME ?=
+
+# Required for deploy/smoke: CLUSTER_NAME
+# OBI exports to the node-local Coralogix collector, so no Coralogix key/region is
+# needed here — deploy opentelemetry/ecs-ec2 on the same cluster first.
+
+.PHONY: help validate create-cluster create-instance-profile create-ec2-instance wait-cluster-capacity create-bucket upload-config prepare-stack deploy status tasks smoke delete delete-ec2-instance delete-cluster delete-bucket cleanup
+
+help:
+	@printf "Coralogix OBI (eBPF instrumentation) ECS CFN helper targets\n\n"
+	@printf "Required vars: CLUSTER_NAME\n"
+	@printf "Optional S3 config override: S3_BUCKET S3_CONFIG_KEY (leave empty to use the embedded default OBI config)\n"
+	@printf "Optional vars: STACK_NAME AWS_REGION TEMPLATE_FILE CONFIG_FILE OBI_IMAGE_REPOSITORY OBI_IMAGE_VERSION CONTEXT_PROPAGATION_MODE OTLP_TRACES_ENDPOINT OTLP_METRICS_ENDPOINT ECS_INSTANCE_PROFILE ECS_EC2_AMI_ID ECS_EC2_AMI_SSM_PARAM EC2_INSTANCE_TYPE EC2_SUBNET_ID EC2_SECURITY_GROUP_ID EC2_KEY_NAME\n\n"
+	@printf "If $(ENV_FILE) exists, values are auto-loaded from it.\n\n"
+	@printf "Targets:\n"
+	@printf "  make validate            Validate CloudFormation template\n"
+	@printf "  make create-cluster      Create ECS cluster if missing\n"
+	@printf "  make create-ec2-instance Create ECS EC2 instance if missing\n"
+	@printf "  make create-bucket       Create S3 bucket if missing\n"
+	@printf "  make upload-config       Upload the OBI config to S3 (only if S3_BUCKET/S3_CONFIG_KEY set)\n"
+	@printf "  make deploy              Deploy stack (with rollback-state recovery)\n"
+	@printf "  make status              Show ECS service status\n"
+	@printf "  make tasks               List ECS tasks for service\n"
+	@printf "  make smoke               Full flow: validate + infra + deploy + checks\n"
+	@printf "  make delete              Delete CloudFormation stack\n"
+	@printf "  make delete-ec2-instance Delete EC2 instances created by this Makefile\n"
+	@printf "  make delete-cluster      Delete ECS cluster if empty\n"
+	@printf "  make delete-bucket       Delete S3 bucket (idempotent)\n"
+	@printf "  make cleanup             delete + delete-ec2-instance + delete-cluster + delete-bucket\n"
+
+require-cluster:
+	@test -n "$(CLUSTER_NAME)" || (echo "Missing required variable: CLUSTER_NAME" && exit 1)
+
+validate:
+	aws cloudformation validate-template --region "$(AWS_REGION)" --template-body "file://$(TEMPLATE_FILE)"
+
+create-cluster: require-cluster
+	@if aws ecs describe-clusters --region "$(AWS_REGION)" --clusters "$(CLUSTER_NAME)" --query "clusters[0].status" --output text | grep -q "^ACTIVE$$"; then \
+		echo "ECS cluster already exists: $(CLUSTER_NAME)"; \
+	else \
+		echo "Creating ECS cluster: $(CLUSTER_NAME)"; \
+		aws ecs create-cluster --region "$(AWS_REGION)" --cluster-name "$(CLUSTER_NAME)" >/dev/null; \
+		echo "ECS cluster created: $(CLUSTER_NAME)"; \
+	fi
+
+create-instance-profile:
+	@if aws iam get-instance-profile --instance-profile-name "$(ECS_INSTANCE_PROFILE)" >/dev/null 2>&1; then \
+		echo "Instance profile already exists: $(ECS_INSTANCE_PROFILE)"; \
+	else \
+		echo "Creating IAM role/instance profile: $(ECS_INSTANCE_PROFILE)"; \
+		if ! aws iam get-role --role-name "$(ECS_INSTANCE_PROFILE)" >/dev/null 2>&1; then \
+			aws iam create-role --role-name "$(ECS_INSTANCE_PROFILE)" --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}' >/dev/null; \
+			aws iam attach-role-policy --role-name "$(ECS_INSTANCE_PROFILE)" --policy-arn "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role" >/dev/null; \
+		fi; \
+		aws iam create-instance-profile --instance-profile-name "$(ECS_INSTANCE_PROFILE)" >/dev/null; \
+		aws iam add-role-to-instance-profile --instance-profile-name "$(ECS_INSTANCE_PROFILE)" --role-name "$(ECS_INSTANCE_PROFILE)" >/dev/null; \
+		echo "Waiting for IAM propagation"; \
+		sleep 10; \
+	fi
+
+create-ec2-instance: create-cluster create-instance-profile require-cluster
+	@registered=$$(aws ecs describe-clusters --region "$(AWS_REGION)" --clusters "$(CLUSTER_NAME)" --query "clusters[0].registeredContainerInstancesCount" --output text); \
+	if [ "$$registered" != "None" ] && [ "$$registered" != "0" ]; then \
+		echo "ECS cluster already has $$registered container instance(s), skipping EC2 creation."; \
+		exit 0; \
+	fi; \
+	if [ -n "$(ECS_EC2_AMI_ID)" ]; then \
+		ami_id="$(ECS_EC2_AMI_ID)"; \
+	else \
+		ami_id=$$(aws ssm get-parameter --region "$(AWS_REGION)" --name "$(ECS_EC2_AMI_SSM_PARAM)" --query "Parameter.Value" --output text); \
+	fi; \
+	if [ -n "$(EC2_SUBNET_ID)" ]; then \
+		subnet_id="$(EC2_SUBNET_ID)"; \
+		vpc_id=$$(aws ec2 describe-subnets --region "$(AWS_REGION)" --subnet-ids "$$subnet_id" --query "Subnets[0].VpcId" --output text); \
+	else \
+		vpc_id=$$(aws ec2 describe-vpcs --region "$(AWS_REGION)" --filters Name=isDefault,Values=true --query "Vpcs[0].VpcId" --output text); \
+		subnet_id=$$(aws ec2 describe-subnets --region "$(AWS_REGION)" --filters Name=vpc-id,Values=$$vpc_id Name=default-for-az,Values=true --query "Subnets[0].SubnetId" --output text); \
+	fi; \
+	if [ "$$subnet_id" = "None" ] || [ -z "$$subnet_id" ]; then \
+		echo "Could not resolve subnet. Set EC2_SUBNET_ID."; \
+		exit 1; \
+	fi; \
+	if [ -n "$(EC2_SECURITY_GROUP_ID)" ]; then \
+		sg_id="$(EC2_SECURITY_GROUP_ID)"; \
+	else \
+		sg_id=$$(aws ec2 describe-security-groups --region "$(AWS_REGION)" --filters Name=vpc-id,Values=$$vpc_id Name=group-name,Values=default --query "SecurityGroups[0].GroupId" --output text); \
+	fi; \
+	if [ "$$sg_id" = "None" ] || [ -z "$$sg_id" ]; then \
+		echo "Could not resolve security group. Set EC2_SECURITY_GROUP_ID."; \
+		exit 1; \
+	fi; \
+	user_data=$$(printf '#!/bin/bash\ncat <<EOF >> /etc/ecs/ecs.config\nECS_CLUSTER=%s\nECS_ENABLE_TASK_IAM_ROLE=true\nECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true\nEOF\n' "$(CLUSTER_NAME)"); \
+	echo "Launching ECS EC2 instance into cluster $(CLUSTER_NAME)"; \
+	if [ -n "$(EC2_KEY_NAME)" ]; then \
+		instance_id=$$(aws ec2 run-instances --region "$(AWS_REGION)" --image-id "$$ami_id" --instance-type "$(EC2_INSTANCE_TYPE)" --iam-instance-profile Name="$(ECS_INSTANCE_PROFILE)" --subnet-id "$$subnet_id" --security-group-ids "$$sg_id" --key-name "$(EC2_KEY_NAME)" --user-data "$$user_data" --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$(CLUSTER_NAME)-ecs-container-instance},{Key=ManagedBy,Value=coralogix-obi-makefile},{Key=ClusterName,Value=$(CLUSTER_NAME)}]" --query "Instances[0].InstanceId" --output text); \
+	else \
+		instance_id=$$(aws ec2 run-instances --region "$(AWS_REGION)" --image-id "$$ami_id" --instance-type "$(EC2_INSTANCE_TYPE)" --iam-instance-profile Name="$(ECS_INSTANCE_PROFILE)" --subnet-id "$$subnet_id" --security-group-ids "$$sg_id" --user-data "$$user_data" --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=$(CLUSTER_NAME)-ecs-container-instance},{Key=ManagedBy,Value=coralogix-obi-makefile},{Key=ClusterName,Value=$(CLUSTER_NAME)}]" --query "Instances[0].InstanceId" --output text); \
+	fi; \
+	echo "Created EC2 instance: $$instance_id"; \
+	aws ec2 wait instance-running --region "$(AWS_REGION)" --instance-ids "$$instance_id"
+
+wait-cluster-capacity: require-cluster
+	@echo "Waiting for ECS container instance registration in cluster $(CLUSTER_NAME)"; \
+	for i in $$(seq 1 30); do \
+		registered=$$(aws ecs describe-clusters --region "$(AWS_REGION)" --clusters "$(CLUSTER_NAME)" --query "clusters[0].registeredContainerInstancesCount" --output text); \
+		if [ "$$registered" != "None" ] && [ "$$registered" != "0" ]; then \
+			echo "ECS container instances registered: $$registered"; \
+			exit 0; \
+		fi; \
+		sleep 10; \
+	done; \
+	echo "Timed out waiting for ECS container instance registration."; \
+	exit 1
+
+create-bucket:
+	@if [ -z "$(S3_BUCKET)" ]; then \
+		echo "S3_BUCKET is not configured, skipping bucket creation."; \
+	elif aws s3api head-bucket --bucket "$(S3_BUCKET)" >/dev/null 2>&1; then \
+		echo "S3 bucket already exists: $(S3_BUCKET)"; \
+	else \
+		echo "Creating S3 bucket: $(S3_BUCKET) in region $(AWS_REGION)"; \
+		if [ "$(AWS_REGION)" = "us-east-1" ]; then \
+			aws s3api create-bucket --bucket "$(S3_BUCKET)" --region "$(AWS_REGION)"; \
+		else \
+			aws s3api create-bucket --bucket "$(S3_BUCKET)" --region "$(AWS_REGION)" --create-bucket-configuration LocationConstraint="$(AWS_REGION)"; \
+		fi; \
+	fi
+
+upload-config:
+	@set -e; \
+	if [ -z "$(S3_BUCKET)" ] || [ -z "$(S3_CONFIG_KEY)" ]; then \
+		echo "S3_BUCKET/S3_CONFIG_KEY not configured, skipping config upload (embedded default OBI config will be used)."; \
+	else \
+		aws s3 cp "$(CONFIG_FILE)" "s3://$(S3_BUCKET)/$(S3_CONFIG_KEY)" --region "$(AWS_REGION)"; \
+	fi
+
+prepare-stack:
+	@status=$$(aws cloudformation describe-stacks --region "$(AWS_REGION)" --stack-name "$(STACK_NAME)" --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "NOT_FOUND"); \
+	case "$$status" in \
+		NOT_FOUND) echo "Stack not found, will create: $(STACK_NAME)" ;; \
+		ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED) \
+			echo "Stack $(STACK_NAME) is in $$status, deleting before deploy"; \
+			aws cloudformation delete-stack --region "$(AWS_REGION)" --stack-name "$(STACK_NAME)"; \
+			aws cloudformation wait stack-delete-complete --region "$(AWS_REGION)" --stack-name "$(STACK_NAME)" ;; \
+		DELETE_IN_PROGRESS) \
+			echo "Stack deletion in progress, waiting: $(STACK_NAME)"; \
+			aws cloudformation wait stack-delete-complete --region "$(AWS_REGION)" --stack-name "$(STACK_NAME)" ;; \
+		CREATE_IN_PROGRESS|UPDATE_IN_PROGRESS|UPDATE_COMPLETE_CLEANUP_IN_PROGRESS|UPDATE_ROLLBACK_IN_PROGRESS|UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS|REVIEW_IN_PROGRESS) \
+			echo "Stack is currently busy ($$status). Wait for completion and retry."; \
+			exit 1 ;; \
+		*) echo "Stack status is $$status, proceeding with deploy" ;; \
+	esac
+
+deploy: require-cluster prepare-stack
+	aws cloudformation deploy \
+		--template-file "$(TEMPLATE_FILE)" \
+		--stack-name "$(STACK_NAME)" \
+		--region "$(AWS_REGION)" \
+		--capabilities CAPABILITY_NAMED_IAM \
+		--parameter-overrides \
+			ClusterName="$(CLUSTER_NAME)" \
+			ObiImageRepository="$(OBI_IMAGE_REPOSITORY)" \
+			ObiImageVersion="$(OBI_IMAGE_VERSION)" \
+			ContextPropagationMode="$(CONTEXT_PROPAGATION_MODE)" \
+			OtlpTracesEndpoint="$(OTLP_TRACES_ENDPOINT)" \
+			OtlpMetricsEndpoint="$(OTLP_METRICS_ENDPOINT)" \
+			S3ConfigBucket="$(S3_BUCKET)" \
+			S3ConfigKey="$(S3_CONFIG_KEY)"
+
+status:
+	aws ecs describe-services \
+		--region "$(AWS_REGION)" \
+		--cluster "$(CLUSTER_NAME)" \
+		--services "$(SERVICE_NAME)" \
+		--query "services[0].{status:status,desired:desiredCount,running:runningCount,pending:pendingCount,events:events[0:5].message}"
+
+tasks:
+	aws ecs list-tasks \
+		--region "$(AWS_REGION)" \
+		--cluster "$(CLUSTER_NAME)" \
+		--service-name "$(SERVICE_NAME)"
+
+smoke: validate create-cluster create-ec2-instance wait-cluster-capacity create-bucket upload-config deploy status tasks
+
+delete:
+	@status=$$(aws cloudformation describe-stacks --region "$(AWS_REGION)" --stack-name "$(STACK_NAME)" --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "NOT_FOUND"); \
+	if [ "$$status" = "NOT_FOUND" ]; then \
+		echo "Stack does not exist, skipping: $(STACK_NAME)"; \
+	else \
+		echo "Deleting stack: $(STACK_NAME)"; \
+		aws cloudformation delete-stack --stack-name "$(STACK_NAME)" --region "$(AWS_REGION)"; \
+		echo "Waiting for stack deletion: $(STACK_NAME)"; \
+		aws cloudformation wait stack-delete-complete --stack-name "$(STACK_NAME)" --region "$(AWS_REGION)"; \
+		echo "Stack deleted: $(STACK_NAME)"; \
+	fi
+
+delete-ec2-instance: require-cluster
+	@instance_ids=$$(aws ec2 describe-instances --region "$(AWS_REGION)" --filters Name=tag:ManagedBy,Values=coralogix-obi-makefile Name=tag:ClusterName,Values="$(CLUSTER_NAME)" Name=instance-state-name,Values=pending,running,stopping,stopped --query "Reservations[].Instances[].InstanceId" --output text); \
+	if [ -z "$$instance_ids" ] || [ "$$instance_ids" = "None" ]; then \
+		echo "No managed EC2 instances found for cluster $(CLUSTER_NAME)."; \
+		exit 0; \
+	fi; \
+	echo "Terminating EC2 instance(s): $$instance_ids"; \
+	aws ec2 terminate-instances --region "$(AWS_REGION)" --instance-ids $$instance_ids >/dev/null; \
+	aws ec2 wait instance-terminated --region "$(AWS_REGION)" --instance-ids $$instance_ids
+
+delete-cluster: require-cluster
+	@status=$$(aws ecs describe-clusters --region "$(AWS_REGION)" --clusters "$(CLUSTER_NAME)" --query "clusters[0].status" --output text); \
+	if [ "$$status" != "ACTIVE" ]; then \
+		echo "ECS cluster does not exist or is not active, skipping: $(CLUSTER_NAME)"; \
+		exit 0; \
+	fi; \
+	services=$$(aws ecs list-services --region "$(AWS_REGION)" --cluster "$(CLUSTER_NAME)" --query "length(serviceArns)" --output text); \
+	tasks=$$(aws ecs list-tasks --region "$(AWS_REGION)" --cluster "$(CLUSTER_NAME)" --query "length(taskArns)" --output text); \
+	instances=$$(aws ecs list-container-instances --region "$(AWS_REGION)" --cluster "$(CLUSTER_NAME)" --query "length(containerInstanceArns)" --output text); \
+	if [ "$$services" != "0" ] || [ "$$tasks" != "0" ] || [ "$$instances" != "0" ]; then \
+		echo "ECS cluster is not empty. services=$$services tasks=$$tasks instances=$$instances"; \
+		exit 1; \
+	fi; \
+	echo "Deleting ECS cluster: $(CLUSTER_NAME)"; \
+	aws ecs delete-cluster --region "$(AWS_REGION)" --cluster "$(CLUSTER_NAME)" >/dev/null
+
+delete-bucket:
+	@if [ -z "$(S3_BUCKET)" ]; then \
+		echo "S3_BUCKET is not configured, skipping bucket deletion."; \
+	elif aws s3api head-bucket --bucket "$(S3_BUCKET)" >/dev/null 2>&1; then \
+		echo "Removing objects from s3://$(S3_BUCKET)"; \
+		aws s3 rm "s3://$(S3_BUCKET)" --recursive --region "$(AWS_REGION)" >/dev/null 2>&1 || true; \
+		echo "Deleting S3 bucket $(S3_BUCKET)"; \
+		aws s3api delete-bucket --bucket "$(S3_BUCKET)" --region "$(AWS_REGION)" >/dev/null 2>&1 || true; \
+	else \
+		echo "S3 bucket does not exist or is not accessible, skipping: $(S3_BUCKET)"; \
+	fi
+
+cleanup: delete delete-ec2-instance delete-cluster delete-bucket
+	@echo "Done"

--- a/opentelemetry/obi-ecs-ec2/README.md
+++ b/opentelemetry/obi-ecs-ec2/README.md
@@ -1,0 +1,78 @@
+# Coralogix OBI (eBPF Instrumentation) — ECS EC2
+
+Deploy [OBI](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation)
+(OpenTelemetry eBPF Instrumentation) as an ECS **DAEMON** service. OBI captures
+application spans & metrics via eBPF (zero-code) for **every process on the host** —
+including services with no OpenTelemetry SDK — and exports OTLP to the node-local
+Coralogix OpenTelemetry Collector, which forwards to Coralogix.
+
+This mirrors the Kubernetes OBI integration (the `opentelemetry-ebpf-instrumentation`
+Helm chart) and the `telemetry-shippers` `otel-ecs-ec2` integration, packaged as a
+CloudFormation template alongside the existing `opentelemetry/ecs-ec2` collector and
+`opentelemetry/ebpf-profiler`.
+
+## Requirements
+
+- **ECS EC2 launch type** — OBI **cannot run on Fargate** (it needs `privileged`
+  mode, host PID namespace, and eBPF host mounts). One task runs per container
+  instance (`SchedulingStrategy: DAEMON`).
+- **Linux kernel >= 5.8** on the container instances.
+- **A collector on the cluster.** OBI exports to the node-local collector, not
+  directly to Coralogix. Deploy [`opentelemetry/ecs-ec2`](../ecs-ec2/) first (it
+  runs as a host-network DAEMON listening on `4317`/`4318`), or point
+  `OtlpTracesEndpoint` / `OtlpMetricsEndpoint` at your own collector.
+
+## How it works
+
+- A privileged `coralogix-obi` container runs the OBI image with host PID/network
+  and the eBPF host mounts (`/sys/fs/cgroup`, `/sys/kernel/debug`,
+  `/sys/kernel/tracing`, `/sys/fs/bpf`), reading its config from
+  `OTEL_EBPF_CONFIG_PATH`.
+- A `config-loader` sidecar writes the OBI config to a shared volume — either the
+  template's embedded default or a file pulled from S3 (`S3ConfigBucket` /
+  `S3ConfigKey`).
+- The default config uses host-process discovery (`open_ports` / `exe_path`),
+  GenAI + DB payload extraction, and exports to `localhost:4317` (traces) /
+  `localhost:4318` (metrics).
+
+## Parameters
+
+| Parameter | Default | Description |
+| --- | --- | --- |
+| `ClusterName` | — (required) | Existing ECS cluster (EC2 launch type). |
+| `ObiImageRepository` | `ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument` | OBI image repository. |
+| `ObiImageVersion` | `v0.10.0` | OBI image tag. |
+| `ContextPropagationMode` | `headers,tcp` | eBPF distributed context propagation; `disabled` to turn off. |
+| `OtlpTracesEndpoint` | `http://localhost:4317` | OTLP gRPC endpoint for traces (the node-local collector). |
+| `OtlpMetricsEndpoint` | `http://localhost:4318` | OTLP HTTP endpoint for metrics (the node-local collector). |
+| `S3ConfigBucket` | `""` | Optional S3 bucket to load a custom OBI config from. |
+| `S3ConfigKey` | `""` | Optional S3 key for the OBI config. |
+
+## Deploy
+
+Using the AWS CLI:
+
+```bash
+aws cloudformation deploy \
+  --template-file template.yaml \
+  --stack-name coralogix-obi \
+  --region <region> \
+  --capabilities CAPABILITY_NAMED_IAM \
+  --parameter-overrides ClusterName=<your-ecs-cluster>
+```
+
+Or with the helper Makefile (auto-loads `.env`; see `.env.example`):
+
+```bash
+cp .env.example .env   # set CLUSTER_NAME
+make deploy            # deploy against an existing cluster + collector
+make status            # show the ECS service
+make smoke             # full flow: create cluster + EC2 instance + deploy + checks
+make cleanup           # tear everything down
+```
+
+## Scoping what gets instrumented
+
+Edit `examples/obi-config.yaml` (or the embedded default in `template.yaml`) —
+narrow `discovery.instrument` to specific ports or `exe_path` globs — then upload it
+to S3 and set `S3ConfigBucket` / `S3ConfigKey`.

--- a/opentelemetry/obi-ecs-ec2/examples/obi-config.yaml
+++ b/opentelemetry/obi-ecs-ec2/examples/obi-config.yaml
@@ -1,0 +1,66 @@
+# Example OBI (OpenTelemetry eBPF Instrumentation) configuration for ECS EC2.
+# This mirrors the template's embedded default. Upload it to S3 and set
+# S3ConfigBucket / S3ConfigKey to override the embedded config.
+#
+# OBI exports OTLP to the node-local Coralogix collector (host networking →
+# localhost), which forwards to Coralogix.
+discovery:
+  # Instrument every process with a listening port. Narrow this (e.g. a port
+  # range or exe_path globs) to scope instrumentation.
+  instrument:
+    - open_ports: "1-65535"
+  exclude_instrument:
+    - exe_path: "*ebpf-instrument*"
+    - exe_path: "*otelcol*"
+    - exe_path: "*obi*"
+attributes:
+  select:
+    '*':
+      include:
+        - gen_ai.*
+ebpf:
+  buffer_sizes:
+    http: 2048
+    kafka: 4096
+    mysql: 4096
+    postgres: 4096
+  payload_extraction:
+    http:
+      aws:
+        enabled: true
+      elasticsearch:
+        enabled: true
+      genai:
+        anthropic:
+          enabled: true
+        embedding:
+          enabled: true
+        gemini:
+          enabled: true
+        mcp:
+          enabled: true
+        openai:
+          enabled: true
+        qwen:
+          enabled: true
+        rerank:
+          enabled: true
+        retrieval:
+          enabled: true
+      graphql:
+        enabled: true
+      jsonrpc:
+        enabled: true
+      sqlpp:
+        enabled: true
+  redis_db_cache:
+    enabled: true
+health_check:
+  port: 0
+otel_traces_export:
+  endpoint: "http://localhost:4317"
+otel_metrics_export:
+  endpoint: "http://localhost:4318"
+prometheus_export:
+  port: 9090
+  path: /metrics

--- a/opentelemetry/obi-ecs-ec2/examples/obi-config.yaml
+++ b/opentelemetry/obi-ecs-ec2/examples/obi-config.yaml
@@ -15,9 +15,9 @@ discovery:
     - exe_path: "*obi*"
 attributes:
   select:
-    '*':
+    traces:
       include:
-        - gen_ai.*
+        - '*'
 ebpf:
   buffer_sizes:
     http: 2048

--- a/opentelemetry/obi-ecs-ec2/template.yaml
+++ b/opentelemetry/obi-ecs-ec2/template.yaml
@@ -167,9 +167,9 @@ Resources:
                     - exe_path: "*obi*"
                 attributes:
                   select:
-                    '*':
+                    traces:
                       include:
-                        - gen_ai.*
+                        - '*'
                 ebpf:
                   buffer_sizes:
                     http: 2048

--- a/opentelemetry/obi-ecs-ec2/template.yaml
+++ b/opentelemetry/obi-ecs-ec2/template.yaml
@@ -1,0 +1,329 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: |
+  Create an OpenTelemetry eBPF Instrumentation (OBI) ECS Daemon Service on an ECS Cluster.
+  OBI captures application spans & metrics via eBPF (zero-code) for every process on the
+  host and exports OTLP to the node-local Coralogix OpenTelemetry Collector, which forwards
+  to Coralogix. Deploy the Coralogix OTel Collector (opentelemetry/ecs-ec2) on the same
+  cluster first — OBI ships to it, not directly to Coralogix.
+
+  Requirements: ECS EC2 launch type (OBI cannot run on Fargate — it needs privileged mode,
+  host PID, and eBPF host mounts) and Linux kernel >= 5.8 on the container instances.
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "Basic Configuration"
+        Parameters:
+          - ClusterName
+          - ObiImageRepository
+          - ObiImageVersion
+          - ContextPropagationMode
+      - Label:
+          default: "OTLP Export (to the node-local collector)"
+        Parameters:
+          - OtlpTracesEndpoint
+          - OtlpMetricsEndpoint
+      - Label:
+          default: "S3 Configuration (Optional)"
+        Parameters:
+          - S3ConfigBucket
+          - S3ConfigKey
+    ParameterLabels:
+      ClusterName:
+        default: "ECS Cluster Name"
+      ObiImageRepository:
+        default: "OBI Image Repository"
+      ObiImageVersion:
+        default: "OBI Image Version"
+      ContextPropagationMode:
+        default: "eBPF Context Propagation Mode"
+      OtlpTracesEndpoint:
+        default: "OTLP Traces Endpoint"
+      OtlpMetricsEndpoint:
+        default: "OTLP Metrics Endpoint"
+      S3ConfigBucket:
+        default: "S3 Bucket Name"
+      S3ConfigKey:
+        default: "S3 OBI Config Key"
+
+Parameters:
+  ClusterName:
+    Type: String
+    Description: Name of an existing ECS cluster (EC2 launch type)
+    AllowedPattern: ".+"
+    ConstraintDescription: ECS cluster name is required.
+
+  ObiImageRepository:
+    Type: String
+    Description: OBI (ebpf-instrument) image repository
+    Default: ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument
+    AllowedPattern: ".+"
+    ConstraintDescription: OBI image repository is required.
+
+  ObiImageVersion:
+    Type: String
+    Description: OBI (ebpf-instrument) image version/tag
+    Default: v0.10.0
+    AllowedPattern: ".+"
+    ConstraintDescription: OBI image version is required.
+
+  ContextPropagationMode:
+    Type: String
+    Description: eBPF distributed context propagation mode (OTEL_EBPF_BPF_CONTEXT_PROPAGATION). Set to "disabled" to turn off.
+    Default: "headers,tcp"
+    AllowedValues:
+      - "headers,tcp"
+      - "headers"
+      - "tcp"
+      - "disabled"
+
+  OtlpTracesEndpoint:
+    Type: String
+    Description: OTLP gRPC endpoint OBI exports traces to. With host networking this is the local collector.
+    Default: "http://localhost:4317"
+    AllowedPattern: ".+"
+
+  OtlpMetricsEndpoint:
+    Type: String
+    Description: OTLP HTTP endpoint OBI exports metrics to. With host networking this is the local collector.
+    Default: "http://localhost:4318"
+    AllowedPattern: ".+"
+
+  S3ConfigBucket:
+    Type: String
+    Description: S3 bucket containing an OBI configuration file. Optional — leave empty to use the embedded default configuration.
+    Default: ""
+
+  S3ConfigKey:
+    Type: String
+    Description: S3 object key for the OBI configuration. Optional — leave empty to use the embedded default configuration.
+    Default: ""
+
+Conditions:
+  UseS3Config: !And
+    - !Not [!Equals [!Ref S3ConfigBucket, ""]]
+    - !Not [!Equals [!Ref S3ConfigKey, ""]]
+  PropagationEnabled: !Not [!Equals [!Ref ContextPropagationMode, "disabled"]]
+
+Resources:
+  ObiTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      ExecutionRoleArn: !Ref ObiTaskExecutionRole
+      TaskRoleArn: !If [UseS3Config, !Ref ObiTaskRole, !Ref AWS::NoValue]
+      Family: coralogix-obi
+      RequiresCompatibilities:
+        - EC2
+      NetworkMode: host
+      PidMode: host
+      Volumes:
+        - Name: obi-config
+        - Name: cgroupfs
+          Host:
+            SourcePath: /sys/fs/cgroup
+        - Name: debugfs
+          Host:
+            SourcePath: /sys/kernel/debug
+        - Name: tracefs
+          Host:
+            SourcePath: /sys/kernel/tracing
+        - Name: bpffs
+          Host:
+            SourcePath: /sys/fs/bpf
+
+      ContainerDefinitions:
+        - Name: config-loader
+          Essential: false
+          MemoryReservation: 32
+          Image: public.ecr.aws/aws-cli/aws-cli:2.28.17
+          EntryPoint:
+            - sh
+            - -c
+          Command:
+            - |
+              set -e
+              if [ -n "$S3_CONFIG_BUCKET" ] && [ -n "$S3_CONFIG_KEY" ]; then
+                aws s3 cp "s3://$S3_CONFIG_BUCKET/$S3_CONFIG_KEY" /obi-config/obi-config.yaml
+              else
+                printf '%s\n' "$OBI_CONFIG" > /obi-config/obi-config.yaml
+              fi
+          Environment:
+            - Name: S3_CONFIG_BUCKET
+              Value: !Ref S3ConfigBucket
+            - Name: S3_CONFIG_KEY
+              Value: !Ref S3ConfigKey
+            # Embedded default OBI config. Mirrors the k8s-helm / telemetry-shippers
+            # host config: host-process discovery, GenAI + DB payload extraction, and
+            # OTLP export to the node-local collector.
+            - Name: OBI_CONFIG
+              Value: !Sub |-
+                discovery:
+                  instrument:
+                    - open_ports: "1-65535"
+                  exclude_instrument:
+                    - exe_path: "*ebpf-instrument*"
+                    - exe_path: "*otelcol*"
+                    - exe_path: "*obi*"
+                attributes:
+                  select:
+                    '*':
+                      include:
+                        - gen_ai.*
+                ebpf:
+                  buffer_sizes:
+                    http: 2048
+                    kafka: 4096
+                    mysql: 4096
+                    postgres: 4096
+                  payload_extraction:
+                    http:
+                      aws:
+                        enabled: true
+                      elasticsearch:
+                        enabled: true
+                      genai:
+                        anthropic:
+                          enabled: true
+                        embedding:
+                          enabled: true
+                        gemini:
+                          enabled: true
+                        mcp:
+                          enabled: true
+                        openai:
+                          enabled: true
+                        qwen:
+                          enabled: true
+                        rerank:
+                          enabled: true
+                        retrieval:
+                          enabled: true
+                      graphql:
+                        enabled: true
+                      jsonrpc:
+                        enabled: true
+                      sqlpp:
+                        enabled: true
+                  redis_db_cache:
+                    enabled: true
+                health_check:
+                  port: 0
+                otel_traces_export:
+                  endpoint: "${OtlpTracesEndpoint}"
+                otel_metrics_export:
+                  endpoint: "${OtlpMetricsEndpoint}"
+                prometheus_export:
+                  port: 9090
+                  path: /metrics
+          MountPoints:
+            - SourceVolume: obi-config
+              ContainerPath: /obi-config
+
+        - Name: coralogix-obi
+          Cpu: 0
+          Memory: 512
+          Image: !Sub "${ObiImageRepository}:${ObiImageVersion}"
+          Essential: true
+          User: "0"
+          Privileged: true
+          DependsOn:
+            - ContainerName: config-loader
+              Condition: SUCCESS
+          MountPoints:
+            - SourceVolume: obi-config
+              ContainerPath: /obi-config
+              ReadOnly: true
+            - SourceVolume: cgroupfs
+              ContainerPath: /sys/fs/cgroup
+            - SourceVolume: debugfs
+              ContainerPath: /sys/kernel/debug
+              ReadOnly: true
+            - SourceVolume: tracefs
+              ContainerPath: /sys/kernel/tracing
+              ReadOnly: true
+            - SourceVolume: bpffs
+              ContainerPath: /sys/fs/bpf
+          Environment:
+            - Name: OTEL_EBPF_CONFIG_PATH
+              Value: /obi-config/obi-config.yaml
+            - !If
+              - PropagationEnabled
+              - Name: OTEL_EBPF_BPF_CONTEXT_PROPAGATION
+                Value: !Ref ContextPropagationMode
+              - !Ref AWS::NoValue
+
+  ObiTaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-obi-task-execution-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  ObiTaskRole:
+    Type: AWS::IAM::Role
+    Condition: UseS3Config
+    Properties:
+      RoleName: !Sub "${AWS::StackName}-obi-task-role"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3ReadAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                Resource: !Sub "arn:aws:s3:::${S3ConfigBucket}/*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${S3ConfigBucket}"
+
+  ECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      Cluster: !Ref ClusterName
+      LaunchType: EC2
+      ServiceName: coralogix-obi
+      SchedulingStrategy: DAEMON
+      DeploymentConfiguration:
+        MaximumPercent: 100
+        MinimumHealthyPercent: 0
+        DeploymentCircuitBreaker:
+          Enable: true
+          Rollback: true
+      DeploymentController:
+        Type: ECS
+      ServiceConnectConfiguration:
+        Enabled: false
+      PlacementStrategies: []
+      PlacementConstraints: []
+      EnableECSManagedTags: true
+      Tags:
+        - Key: ecs:service:stackId
+          Value: !Ref AWS::StackId
+      TaskDefinition: !Ref ObiTaskDefinition
+
+Outputs:
+  ServiceName:
+    Description: ECS service name
+    Value: coralogix-obi
+
+  ServiceArn:
+    Description: ECS service ARN
+    Value: !Ref ECSService


### PR DESCRIPTION
# Description

Adds `opentelemetry/obi-ecs-ec2` — a CloudFormation template that deploys **OBI** (OpenTelemetry eBPF Instrumentation, `ghcr.io/open-telemetry/opentelemetry-ebpf-instrumentation/ebpf-instrument:v0.10.0`) as an ECS **EC2 DAEMON** service. OBI instruments **every process on the host** via eBPF (zero-code — including services with no OTel SDK) and exports OTLP to the node-local Coralogix collector (`opentelemetry/ecs-ec2`), which forwards to Coralogix.

This is the ECS packaging of OBI, matching the Kubernetes OBI Helm integration and the `telemetry-shippers` `otel-ecs-ec2` work. It closes the gap raised in the SE discussion: shipping the chart config wasn't enough for ECS — customers deploy the collector via this CFN repo, so OBI needs a template here too.

Modeled directly on the existing `opentelemetry/ebpf-profiler` template, which already proves the required pattern: **EC2 launch type, `Privileged: true`, `NetworkMode: host`, `PidMode: host`, `User: "0"`, eBPF host mounts, `config-loader` sidecar (embedded default or S3 override), `SchedulingStrategy: DAEMON`**. Deltas from the profiler: OBI image + entrypoint (`OTEL_EBPF_CONFIG_PATH`, `OTEL_EBPF_BPF_CONTEXT_PROPAGATION`), OBI's `/sys/fs/bpf` + `/sys/kernel/tracing` mounts, and OTLP export to the local collector instead of shipping to Coralogix directly (so **no Coralogix key/region needed here**).

Key constraint (already satisfied by this repo's collectors): OBI **cannot run on Fargate** — it needs privileged + host PID + eBPF mounts. Requires **EC2 launch type** and **Linux kernel ≥ 5.8**.

Contents: `template.yaml`, `README.md`, `CHANGELOG.md`, helper `Makefile` (validate/deploy/smoke/cleanup), `.env.example`, and `examples/obi-config.yaml`.

# How Has This Been Tested?

- **`cfn-lint` clean** — the only findings are the same two `E1041` (`!Ref` on IAM role for `ExecutionRoleArn`) that the already-shipped `opentelemetry/ebpf-profiler/template.yaml` produces; no new issues.
- The OBI task shape (privileged, host PID/net, these exact eBPF mounts, OTLP → node-local collector) was validated end-to-end in the anemia demo and `telemetry-shippers` #969: OBI attaches eBPF probes and exports spans/metrics to Coralogix (`telemetry.distro.name=opentelemetry-ebpf-instrumentation`).
- **Live CloudFormation deploy not yet run** — `make smoke` (create cluster + EC2 instance + deploy) is the next step before marking ready for review.

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)