### PR TITLE
feat(cloud-accounts): add CloudWatch Logs permissions

### DIFF
--- a/cloud-accounts/automatic/CHANGELOG.md
+++ b/cloud-accounts/automatic/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [3.0.0] - 2026-08-11
+
+### Added
+
+- Add `<RoleName>-logs` for CloudWatch Logs delivery to Coralogix-owned Firehose streams.
+- Add `<RoleName>-lm` for least-privilege Lambda manager execution.
+
+### Changed
+
+- Allow the Coralogix-assumed role to manage only generated `cx-lc-*-lm` Lambda managers and `cx-lc-*-lg` EventBridge rules/targets, including the Lambda configuration reads required by AWS SDK waiters, and to pass only the Lambda manager execution role to Lambda.
+- Scope Lambda manager execution to generated manager log groups and configuration, and use log-group ARNs for customer subscription management.
+- Document the CloudTrail prerequisite for discovering newly created log groups.
+
 ## [2.0.0] - 2026-07-03
 
 ### Changed

--- a/cloud-accounts/automatic/README.md
+++ b/cloud-accounts/automatic/README.md
@@ -1,6 +1,6 @@
 # Coralogix Cloud Account Automatic Integration
 
-This CloudFormation template creates a named IAM role that allows Coralogix to collect AWS account metrics and is meant to be used via Cloud Accounts feature in Coralogix.
+This CloudFormation template creates named IAM roles that allow Coralogix to collect AWS account metrics and manage CloudWatch Logs ingestion through the Coralogix Cloud Accounts feature.
 
 The published template URL is:
 
@@ -13,16 +13,19 @@ https://cgx-cloudformation-templates.s3.amazonaws.com/cloud-accounts/automatic/t
 * AWS account permissions to create IAM roles, attach AWS managed policies, and add inline IAM policies.
 * The Coralogix company ID for your account.
 * `CAPABILITY_NAMED_IAM` when deploying, because the stack creates a named IAM role.
+* An active CloudTrail trail that delivers write management events is required for automatic discovery of `STANDARD` log groups created after a log collection configuration is deployed. Existing `STANDARD` log groups are scanned when the configuration is deployed. The template does not create, inspect, or manage CloudTrail resources.
 
 ## IAM Permissions
 
-This template creates three IAM roles:
+This template creates five IAM roles:
 
 * `coralogix-cloud-account` by default, or the custom `RoleName` value. Coralogix assumes this role.
 * `<RoleName>-fh`, a service role trusted by Kinesis Data Firehose.
 * `<RoleName>-ms`, a service role trusted by CloudWatch Metric Streams.
+* `<RoleName>-logs`, a service role trusted by CloudWatch Logs that can write only to customer `cx-*` Firehose delivery streams.
+* `<RoleName>-lm`, an execution role for generated Coralogix `cx-lc-*-lm` Lambda manager functions. It can write only to their Lambda log groups, manage subscriptions on customer log groups, update only generated manager configuration for initial scans, and pass only `<RoleName>-logs` to CloudWatch Logs.
 
-The Coralogix-assumed role keeps AWS `ReadOnlyAccess` and `AWSResourceExplorerFullAccess`. An inline policy allows only the actions needed to manage Coralogix-owned `cx-*` Firehose delivery streams, CloudWatch Metric Streams, backup S3 buckets/objects, and to pass the two service roles to their intended AWS services.
+The Coralogix-assumed role keeps AWS `ReadOnlyAccess` and `AWSResourceExplorerFullAccess`. An inline policy allows only the actions needed to manage Coralogix-owned `cx-*` Firehose delivery streams, CloudWatch Metric Streams, backup S3 buckets/objects, generated `cx-lc-*-lm` Lambda manager functions, and generated `cx-lc-*-lg` EventBridge rules/targets. Its Lambda permissions include the configuration reads used by AWS SDK waiters. It can pass the Firehose, Metric Streams, and Lambda manager roles only to their intended AWS services. It has no CloudTrail management or direct CloudWatch Logs subscription actions.
 
 ## Parameters
 
@@ -30,7 +33,7 @@ The Coralogix-assumed role keeps AWS `ReadOnlyAccess` and `AWSResourceExplorerFu
 |---|---|---|---|
 | `CoralogixRegion` | Coralogix region for your account. Allowed values are `staging`, `EU1`, `EU2`, `AP1`, `AP2`, `AP3`, `US1`, `US2`, `gov1`, and `CustomEndpoint`. | `EU1` | :heavy_check_mark: |
 | `CoralogixCompanyId` | Numeric Coralogix company ID. Used to build `<ExternalIdSecret>@<CoralogixCompanyId>` when `ExternalIdSecret` is provided. | | :heavy_check_mark: |
-| `RoleName` | Name of the main IAM role to create. Static Firehose service roles use this name with `-fh` and `-ms` suffixes. | `coralogix-cloud-account` | |
+| `RoleName` | Name of the main IAM role to create. Static service roles use this name with `-fh`, `-ms`, `-logs`, and `-lm` suffixes. | `coralogix-cloud-account` | |
 | `ExternalIdSecret` | Optional external ID secret for `sts:AssumeRole`. When blank, the trust policy has no external ID condition and the `ExternalId` output is omitted. | | |
 | `CustomAWSAccountId` | Custom 12-digit Coralogix AWS account ID. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |
 | `CustomRoleSuffix` | Custom suffix for the trusted `coralogix-ingestion-<suffix>` role. Required only when `CoralogixRegion` is `CustomEndpoint`. | | |

--- a/cloud-accounts/automatic/template.yaml
+++ b/cloud-accounts/automatic/template.yaml
@@ -1,8 +1,8 @@
 AWSTemplateFormatVersion: 2010-09-09
-Description: Creates an IAM role allowing Coralogix to collect metrics from your AWS account.
+Description: Creates IAM roles allowing Coralogix to collect metrics and manage CloudWatch Logs ingestion in your AWS account.
 
 Metadata:
-  SemanticVersion: 2.0.0
+  SemanticVersion: 3.0.0
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
@@ -42,7 +42,7 @@ Parameters:
   RoleName:
     Type: String
     Default: coralogix-cloud-account
-    Description: The name of the main IAM role that will be created. Static Firehose service roles use this name with -fh and -ms suffixes.
+    Description: The name of the main IAM role that will be created. Static service roles use this name with -fh, -ms, -logs, and -lm suffixes.
     AllowedPattern: '[\w+=,.@-]+'
     MaxLength: 56
   ExternalIdSecret:
@@ -162,13 +162,95 @@ Resources:
                   - firehose:PutRecordBatch
                 Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/cx-*
 
+  CoralogixCloudWatchLogsServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${RoleName}-logs"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: logs.amazonaws.com
+            Action:
+              - sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount: !Ref AWS::AccountId
+              ArnLike:
+                aws:SourceArn: !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:*
+      Policies:
+        - PolicyName: CoralogixFirehosePutAccess
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - firehose:PutRecord
+                  - firehose:PutRecordBatch
+                Resource: !Sub arn:${AWS::Partition}:firehose:*:${AWS::AccountId}:deliverystream/cx-*
+
+  CoralogixLambdaManagerExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "${RoleName}-lm"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: CoralogixLambdaManagerExecution
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: CreateCoralogixLambdaLogGroups
+                Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                Resource: !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/cx-lc-*-lm
+              - Sid: WriteCoralogixLambdaLogs
+                Effect: Allow
+                Action:
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:/aws/lambda/cx-lc-*-lm:log-stream:*
+              - Sid: DescribeCustomerLogGroups
+                Effect: Allow
+                Action:
+                  - logs:DescribeLogGroups
+                Resource: "*"
+              - Sid: ManageCustomerLogGroupSubscriptions
+                Effect: Allow
+                Action:
+                  - logs:DescribeSubscriptionFilters
+                  - logs:PutSubscriptionFilter
+                Resource: !Sub arn:${AWS::Partition}:logs:*:${AWS::AccountId}:log-group:*
+              - Sid: UpdateCoralogixLambdaManagerConfiguration
+                Effect: Allow
+                Action:
+                  - lambda:GetFunctionConfiguration
+                  - lambda:UpdateFunctionConfiguration
+                Resource: !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:cx-lc-*-lm
+              - Sid: PassCoralogixCloudWatchLogsServiceRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !GetAtt CoralogixCloudWatchLogsServiceRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: logs.amazonaws.com
+
   CoralogixAwsMetricsRole:
     Type: AWS::IAM::Role
     Properties:
       RoleName: !Ref RoleName
       Tags:
         - Key: CoralogixCloudAccountTemplateVersion
-          Value: "2"
+          Value: "3"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -232,6 +314,26 @@ Resources:
                 Action:
                   - s3:DeleteObject
                 Resource: !Sub arn:${AWS::Partition}:s3:::cx-*/*
+              - Sid: ManageCoralogixLambdaManagers
+                Effect: Allow
+                Action:
+                  - lambda:AddPermission
+                  - lambda:CreateFunction
+                  - lambda:DeleteFunction
+                  - lambda:GetFunctionConfiguration
+                  - lambda:InvokeFunction
+                  - lambda:RemovePermission
+                  - lambda:UpdateFunctionCode
+                  - lambda:UpdateFunctionConfiguration
+                Resource: !Sub arn:${AWS::Partition}:lambda:*:${AWS::AccountId}:function:cx-lc-*-lm
+              - Sid: ManageCoralogixEventBridgeRules
+                Effect: Allow
+                Action:
+                  - events:DeleteRule
+                  - events:PutRule
+                  - events:PutTargets
+                  - events:RemoveTargets
+                Resource: !Sub arn:${AWS::Partition}:events:*:${AWS::AccountId}:rule/cx-lc-*-lg
               - Sid: PassCoralogixFirehoseServiceRole
                 Effect: Allow
                 Action:
@@ -248,6 +350,14 @@ Resources:
                 Condition:
                   StringEquals:
                     iam:PassedToService: streams.metrics.cloudwatch.amazonaws.com
+              - Sid: PassCoralogixLambdaManagerExecutionRole
+                Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !GetAtt CoralogixLambdaManagerExecutionRole.Arn
+                Condition:
+                  StringEquals:
+                    iam:PassedToService: lambda.amazonaws.com
 
 Outputs:
   CoralogixAwsMetricsRoleArn:


### PR DESCRIPTION
# Description

The change allows cloud-accounts to deploy lambda which automatically create cloudwatch log group filter subscriptions to ship logs to coralogix

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes CX-53847

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"master","parentHead":"","trunk":"master"}
```
-->
